### PR TITLE
Use chk:: for lifecycle

### DIFF
--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -17,7 +17,7 @@ NULL
 #' @export
 chk_count <- function(x, x_name = NULL) {
   deprecate_soft("0.2.0",
-    what = "chk_count()",
+    what = "chk::chk_count()",
     details = "Please use `chk_whole_number()` and `chk_gte()` instead"
   )
   if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
@@ -34,7 +34,7 @@ chk_count <- function(x, x_name = NULL) {
 #' @export
 chk_dirs <- function(x) {
   deprecate_soft("0.2.0",
-    what = "chk_dirs()",
+    what = "chk::chk_dirs()",
     details = "Please use `chk_all(x, chk_dir)` instead"
   )
   chk_all(x, chk_dir)
@@ -49,7 +49,7 @@ chk_dirs <- function(x) {
 #' @export
 chk_files <- function(x) {
   deprecate_soft("0.2.0",
-    what = "chk_files()",
+    what = "chk::chk_files()",
     details = "Please use `chk_all(x, chk_file)` instead"
   )
   chk_all(x, chk_file)
@@ -66,8 +66,8 @@ chk_has <- function(x, values, x_name = NULL) {
   if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
   chk_superset(x, values, x_name = x_name)
   deprecate_soft("0.2.0",
-    what = "chk_has()",
-    with = "chk_superset()"
+    what = "chk::chk_has()",
+    with = "chk::chk_superset()"
   )
   invisible()
 }
@@ -83,8 +83,8 @@ chk_in <- function(x, values, x_name = NULL) {
   if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
   chk_subset(x, values, x_name = x_name)
   deprecate_soft("0.2.0",
-    what = "chk_in()",
-    with = "chk_subset()"
+    what = "chk::chk_in()",
+    with = "chk::chk_subset()"
   )
   invisible()
 }
@@ -98,7 +98,7 @@ chk_in <- function(x, values, x_name = NULL) {
 #' @export
 chk_is <- function(x, class, x_name = NULL) {
   deprecate_soft("0.2.0",
-    what = "chk_is()",
+    what = "chk::chk_is()",
     details = "Please use `chk_s3_class()` or `chk_s4_class()` instead",
     id = "chk_is"
   )
@@ -120,7 +120,7 @@ chk_is <- function(x, class, x_name = NULL) {
 #' @export
 vld_is <- function(x, class) {
   deprecate_soft("0.2.0",
-    what = "vld_is()",
+    what = "chk::vld_is()",
     details = "Please use `vld_s3_class()` or `vld_s4_class()` instead",
     id = "chk_is"
   )
@@ -138,8 +138,8 @@ vld_is <- function(x, class) {
 #' @export
 chk_length <- function(x, length = 1L, x_name = NULL) {
   deprecate_soft("0.2.0",
-    what = "chk_length()",
-    with = "chk_range()"
+    what = "chk::chk_length()",
+    with = "chk::chk_range()"
   )
   if (length(x) == length) {
     return(TRUE)
@@ -157,7 +157,7 @@ chk_length <- function(x, length = 1L, x_name = NULL) {
 #' @export
 chk_no_missing <- function(x, x_name = NULL) {
   deprecate_soft("0.2.0",
-    what = "chk_no_missing()", with = "chk_not_any_na()",
+    what = "chk::chk_no_missing()", with = "chk::chk_not_any_na()",
     id = "chk_no_missing"
   )
   if (vld_no_missing(x)) {
@@ -176,7 +176,7 @@ chk_no_missing <- function(x, x_name = NULL) {
 #' @export
 vld_no_missing <- function(x) {
   deprecate_soft("0.2.0",
-    what = "vld_no_missing()", with = "vld_not_any_na()",
+    what = "chk::vld_no_missing()", with = "chk::vld_not_any_na()",
     id = "chk_no_missing"
   )
   !anyNA(x)
@@ -191,7 +191,7 @@ vld_no_missing <- function(x) {
 #' @export
 chk_off <- function() {
   deprecate_warn("0.2.0",
-    what = "chk_off()",
+    what = "chk::chk_off()",
     details = "This approach is no longer recommended"
   )
   options(chk.on = FALSE)
@@ -206,7 +206,7 @@ chk_off <- function() {
 #' @export
 chk_on <- function() {
   deprecate_warn("0.2.0",
-    what = "chk_on()",
+    what = "chk::chk_on()",
     details = "This approach is no longer recommended"
   )
   options(chk.on = TRUE)
@@ -221,7 +221,7 @@ chk_on <- function() {
 #' @export
 is_chk_on <- function() {
   deprecate_warn("0.2.0",
-    what = "is_chk_on()",
+    what = "chk::is_chk_on()",
     details = "This approach is no longer recommended"
   )
   getOption("chk.on", TRUE)
@@ -236,7 +236,7 @@ is_chk_on <- function() {
 #' @export
 chk_proportion <- function(x, x_name = NULL) {
   deprecate_soft("0.2.0",
-    what = "chk_proportion()",
+    what = "chk::chk_proportion()",
     details = "Please use `chk_number(x)` or `chk_range(x)` instead"
   )
   if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
@@ -253,8 +253,8 @@ chk_proportion <- function(x, x_name = NULL) {
 #' @export
 deparse_backtick <- function(x) {
   deprecate_soft("0.2.0",
-    what = "deparse_backtick()",
-    with = "deparse_backtick_chk()"
+    what = "chk::deparse_backtick()",
+    with = "chk::deparse_backtick_chk()"
   )
   deparse_backtick_chk(x)
 }


### PR DESCRIPTION
for better error messages. Also get rid of `.Deprecated()`.