### PR TITLE
update arg '.subclass' to 'class' in rlang calls

### DIFF
--- a/R/chk-is.R
+++ b/R/chk-is.R
@@ -19,7 +19,8 @@ chk_is <- function(x, class, x_name = NULL) {
     return(invisible(x))
   }
   if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
-  abort_chk(x_name, " must inherit from class '", class, "'", x = x, class = class)
+  .class <- class
+  abort_chk(x_name, " must inherit from class '", .class, "'", x = x, .class = .class)
 }
 
 #' @describeIn chk_is Validate Inherits from Class

--- a/R/chk-s3-class.R
+++ b/R/chk-s3-class.R
@@ -20,7 +20,8 @@ chk_s3_class <- function(x, class, x_name = NULL) {
     return(invisible(x))
   }
   if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
-  abort_chk(x_name, " must inherit from S3 class '", class, "'", x = x, class = class)
+  .class <- class
+  abort_chk(x_name, " must inherit from S3 class '", .class, "'", x = x, .class = .class)
 }
 
 #' @describeIn chk_s3_class Validate Inherits from S3 Class

--- a/R/chk-s4-class.R
+++ b/R/chk-s4-class.R
@@ -20,7 +20,8 @@ chk_s4_class <- function(x, class, x_name = NULL) {
     return(invisible(x))
   }
   if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
-  abort_chk(x_name, " must inherit from S4 class '", class, "'", x = x, class = class)
+  .class <- class
+  abort_chk(x_name, " must inherit from S4 class '", .class, "'", x = x, .class = .class)
 }
 
 #' @describeIn chk_s4_class Validate Inherits from S4 Class

--- a/R/err.R
+++ b/R/err.R
@@ -55,7 +55,7 @@ message_chk <- function(..., n = NULL, tidy = TRUE) {
 #'  [rlang::inform()], respectively.
 #'
 #'  The user can set the subclass.
-#'
+#' @param .subclass A string of the class of the error message.
 #' @inheritParams base::stop
 #' @inheritParams rlang::abort
 #' @inheritParams message_chk
@@ -86,7 +86,7 @@ err <- function(..., n = NULL, tidy = TRUE, .subclass = NULL) {
   exec(
     abort,
     msg,
-    .subclass = .subclass,
+    class = .subclass,
     !!!args[named]
   )
 }
@@ -100,7 +100,7 @@ err <- function(..., n = NULL, tidy = TRUE, .subclass = NULL) {
 #' # wrn
 #' wrn("there %r %n problem value%s", n = 2)
 wrn <- function(..., n = NULL, tidy = TRUE, .subclass = NULL) {
-  warn(message_chk(..., n = n, tidy = tidy), .subclass = .subclass)
+  warn(message_chk(..., n = n, tidy = tidy), class = .subclass)
 }
 
 #' @describeIn err Message
@@ -112,5 +112,5 @@ wrn <- function(..., n = NULL, tidy = TRUE, .subclass = NULL) {
 #' # msg
 #' msg("there %r %n problem value%s", n = 2)
 msg <- function(..., n = NULL, tidy = TRUE, .subclass = NULL) {
-  inform(message_chk(..., n = n, tidy = tidy), .subclass = .subclass)
+  inform(message_chk(..., n = n, tidy = tidy), class = .subclass)
 }

--- a/man/err.Rd
+++ b/man/err.Rd
@@ -21,10 +21,7 @@ msg(..., n = NULL, tidy = TRUE, .subclass = NULL)
 
 \item{tidy}{A flag specifying whether capitalize the first character and add a missing period.}
 
-\item{.subclass}{This argument was renamed to \code{class} in rlang
-0.4.2.  It will be deprecated in the next major version. This is
-for consistency with our conventions for class constructors
-documented in \url{https://adv-r.hadley.nz/s3.html#s3-subclassing}.}
+\item{.subclass}{A string of the class of the error message.}
 }
 \description{
 The functions call \code{\link[=message_chk]{message_chk()}} to process

--- a/man/expect_chk_error.Rd
+++ b/man/expect_chk_error.Rd
@@ -23,7 +23,7 @@ within a function or for loop. See \link[testthat]{quasi_label} for more details
 \itemize{
 \item A character vector giving a regular expression that must match the
 error message.
-\item If \code{NULL}, the default, asserts that there should be a error,
+\item If \code{NULL}, the default, asserts that there should be an error,
 but doesn't test for a specific value.
 \item If \code{NA}, asserts that there should be no errors.
 }}


### PR DESCRIPTION
also added work arounds for cases of now duplicated 'class' arg as well as temp fix for docs until fully depricated