### PR TITLE
'scoped_options' to 'local_options' in tests

### DIFF
--- a/man/err.Rd
+++ b/man/err.Rd
@@ -21,10 +21,10 @@ msg(..., n = NULL, tidy = TRUE, .subclass = NULL)
 
 \item{tidy}{A flag specifying whether capitalize the first character and add a missing period.}
 
-\item{.subclass}{This argument was renamed to \code{class} in rlang
-0.4.2.  It will be deprecated in the next major version. This is
-for consistency with our conventions for class constructors
-documented in \url{https://adv-r.hadley.nz/s3.html#s3-subclassing}.}
+\item{.subclass}{\ifelse{{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}} This argument
+was renamed to \code{class} in rlang 0.4.2 for consistency with our
+conventions for class constructors documented in
+\url{https://adv-r.hadley.nz/s3.html#s3-subclassing}.}
 }
 \description{
 The functions call \code{\link[=message_chk]{message_chk()}} to process

--- a/man/expect_chk_error.Rd
+++ b/man/expect_chk_error.Rd
@@ -23,7 +23,7 @@ within a function or for loop. See \link[testthat]{quasi_label} for more details
 \itemize{
 \item A character vector giving a regular expression that must match the
 error message.
-\item If \code{NULL}, the default, asserts that there should be a error,
+\item If \code{NULL}, the default, asserts that there should be an error,
 but doesn't test for a specific value.
 \item If \code{NA}, asserts that there should be no errors.
 }}

--- a/tests/testthat/test-aaa-deprecated.R
+++ b/tests/testthat/test-aaa-deprecated.R
@@ -1,5 +1,5 @@
 test_that("vld_no_missing", {
-  rlang::scoped_options(lifecycle_verbosity = "quiet")
+  rlang::local_options(lifecycle_verbosity = "quiet")
 
   expect_true(vld_no_missing(1))
   expect_true(vld_no_missing(integer(0)))
@@ -8,7 +8,7 @@ test_that("vld_no_missing", {
 })
 
 test_that("chk_no_missing", {
-  rlang::scoped_options(lifecycle_verbosity = "quiet")
+  rlang::local_options(lifecycle_verbosity = "quiet")
 
   expect_null(chk_no_missing(1))
   expect_invisible(chk_no_missing(1))
@@ -18,7 +18,7 @@ test_that("chk_no_missing", {
 
 
 test_that("warning messages are generated for dep functions", {
-  rlang::scoped_options(lifecycle_verbosity = "warning")
+  rlang::local_options(lifecycle_verbosity = "warning")
 
   expect_warning(chk_dirs(tempdir()))
   expect_warning(chk_has(1:3, 1))

--- a/tests/testthat/test-chk-chr.R
+++ b/tests/testthat/test-chk-chr.R
@@ -1,5 +1,5 @@
 test_that("vld_chr", {
-  rlang::scoped_options(lifecycle_verbosity = "quiet")
+  rlang::local_options(lifecycle_verbosity = "quiet")
 
   lifecycle::expect_deprecated(chk_chr(""))
 
@@ -11,7 +11,7 @@ test_that("vld_chr", {
 })
 
 test_that("chk_chr", {
-  rlang::scoped_options(lifecycle_verbosity = "quiet")
+  rlang::local_options(lifecycle_verbosity = "quiet")
 
   lifecycle::expect_deprecated(chk_chr(""))
 

--- a/tests/testthat/test-chk-date-time.R
+++ b/tests/testthat/test-chk-date-time.R
@@ -14,7 +14,7 @@ test_that("chk_date_time", {
 })
 
 test_that("vld_datetime", {
-  rlang::scoped_options(lifecycle_verbosity = "quiet")
+  rlang::local_options(lifecycle_verbosity = "quiet")
   expect_false(vld_datetime(NULL))
   expect_false(vld_datetime(Sys.time()[-1]))
   expect_false(vld_datetime(Sys.time()[c(1, 1)]))
@@ -22,7 +22,7 @@ test_that("vld_datetime", {
 })
 
 test_that("chk_datetime", {
-  rlang::scoped_options(lifecycle_verbosity = "quiet")
+  rlang::local_options(lifecycle_verbosity = "quiet")
   time <- Sys.time()
   expect_identical(chk_date_time(time), time)
   expect_invisible(chk_datetime(Sys.time()))

--- a/tests/testthat/test-chk-dbl.R
+++ b/tests/testthat/test-chk-dbl.R
@@ -1,5 +1,5 @@
 test_that("vld_dbl", {
-  rlang::scoped_options(lifecycle_verbosity = "quiet")
+  rlang::local_options(lifecycle_verbosity = "quiet")
 
   lifecycle::expect_deprecated(vld_dbl(1))
 
@@ -12,7 +12,7 @@ test_that("vld_dbl", {
 })
 
 test_that("chk_dbl", {
-  rlang::scoped_options(lifecycle_verbosity = "quiet")
+  rlang::local_options(lifecycle_verbosity = "quiet")
 
   lifecycle::expect_deprecated(chk_dbl(1))
 

--- a/tests/testthat/test-chk-null-or.R
+++ b/tests/testthat/test-chk-null-or.R
@@ -10,7 +10,7 @@ test_that("chk_null_or works vld", {
 })
 
 test_that("chk_null_or still works chk", {
-  rlang::scoped_options(lifecycle_verbosity = "quiet")
+  rlang::local_options(lifecycle_verbosity = "quiet")
 
   expect_identical(chk_null_or(NULL, chk_number), NULL, chk_number)
   expect_invisible(chk_null_or(NULL, chk_number))
@@ -23,7 +23,7 @@ test_that("chk_null_or still works chk", {
 })
 
 test_that("chk_null_or vld overrides chk", {
-  rlang::scoped_options(lifecycle_verbosity = "quiet")
+  rlang::local_options(lifecycle_verbosity = "quiet")
   expect_identical(chk_null_or(1, chk_flag, vld = vld_number), 1)
   expect_chk_error(
     chk_null_or(1, chk = chk_number, vld = vld_flag),

--- a/tests/testthat/test-chk-wnum.R
+++ b/tests/testthat/test-chk-wnum.R
@@ -1,5 +1,5 @@
 test_that("vld_wnum", {
-  rlang::scoped_options(lifecycle_verbosity = "quiet")
+  rlang::local_options(lifecycle_verbosity = "quiet")
 
   lifecycle::expect_deprecated(vld_wnum(1))
 
@@ -15,7 +15,7 @@ test_that("vld_wnum", {
 })
 
 test_that("chk_wnum", {
-  rlang::scoped_options(lifecycle_verbosity = "quiet")
+  rlang::local_options(lifecycle_verbosity = "quiet")
 
   lifecycle::expect_deprecated(chk_wnum(1))
 

--- a/tests/testthat/test-chkor.R
+++ b/tests/testthat/test-chkor.R
@@ -1,5 +1,5 @@
 test_that("chkor", {
-  rlang::scoped_options(lifecycle_verbosity = "quiet")
+  rlang::local_options(lifecycle_verbosity = "quiet")
 
   expect_null(chkor())
   expect_invisible(chkor())


### PR DESCRIPTION
updating deprecated 'scoped_options'
