### PR TITLE
docs: register usage of poissontemplate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,3 +43,4 @@ Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2.9000
+Config/Needs/website: poissonconsulting/poissontemplate

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,20 +1,7 @@
 url: https://poissonconsulting.github.io/chk/
 template:
   bootstrap: 5
-
-authors:
-  Joe Thorley:
-    href: "https://github.com/joethorley"
-  Kirill Müller:
-    href: "https://github.com/krlmlr"
-  Ayla Pearson:
-    href: "https://github.com/aylapear"
-  Nadine Hussein:
-    href: "https://github.com/nadinehussein"
-  Evan Amies-Galonski:
-    href: "https://github.com/evanamiesgalonski"
-  Poisson Consulting:
-    href: "http://poissonconsulting.ca"
+  package: poissontemplate
 
 reference:
 - title: Logical Scalar Checkers
@@ -95,7 +82,7 @@ reference:
   contents:
   - chk_null
   - chk_not_null
-- title: ... Checkers
+- title: '... Checkers'
   desc: Checking ...
   contents:
   - chk_used


### PR DESCRIPTION
I removed the authors' links because I added them in poissontemplate's default configuration. Note that there I used links on the poissonconsulting website rather than GitHub links as the author profiles on your site are more informative and exhaustive (and link to GitHub anyway).

Locally I was able to render the website without any issue. However I'd appreciate your feedback in order to improve poissontemplate.