### PR TITLE
Update Function Docs - roxygen

### DIFF
--- a/R/chk-all-equal.R
+++ b/R/chk-all-equal.R
@@ -8,7 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_alls
+#' @family equal_checkers
+#' @family all_checkers
+#' @seealso [length()]
+#' @seealso [vld_equal()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_all_equal

--- a/R/chk-all-equivalent.R
+++ b/R/chk-all-equivalent.R
@@ -8,7 +8,14 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_alls
+#' @family equal_checkers
+#' @family all_checkers
+#'
+#' @seealso [length()]
+#' @seealso [vld_equivalent()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_all_equivalent

--- a/R/chk-all-identical.R
+++ b/R/chk-all-identical.R
@@ -13,7 +13,14 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_alls
+#' @family equal_checkers
+#' @family all_checkers
+#'
+#' @seealso [length()]
+#' @seealso [vld_identical()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_all_identical

--- a/R/chk-all.R
+++ b/R/chk-all.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_alls
+#' @family all_checkers
+#'
+#' @seealso [all()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_all

--- a/R/chk-array.R
+++ b/R/chk-array.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_is
+#' @family data_structure_checkers
+#'
+#' @seealso [is.array()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_array

--- a/R/chk-atomic.R
+++ b/R/chk-atomic.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_is
+#' @family data_structure_checkers
+#'
+#' @seealso [is.atomic()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_atomic

--- a/R/chk-character-or-factor.R
+++ b/R/chk-character-or-factor.R
@@ -8,7 +8,14 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_typeof
+#' @family data_type_checkers
+#' @family factor_checkers
+#'
+#' @seealso [is.character()]
+#' @seealso [is.factor()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_character_or_factor

--- a/R/chk-character.R
+++ b/R/chk-character.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_typeof
+#' @family data_type_checkers
+#'
+#' @seealso [is.character()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_character

--- a/R/chk-compatible-lengths.R
+++ b/R/chk-compatible-lengths.R
@@ -15,6 +15,12 @@
 #'   The intent of the function is to check that only strict recycling is
 #'   occurring.
 #'
+#' @family length_checkers
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+#'
 #' @examples
 #' # chk_compatible_lengths
 #'

--- a/R/chk-count.R
+++ b/R/chk-count.R
@@ -8,7 +8,14 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_typeof
+#' @family scalar_checkers
+#' @family whole_number_checkers
+#'
+#' @seealso [vld_whole_number()]
+#' @seealso [length()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_count

--- a/R/chk-data.R
+++ b/R/chk-data.R
@@ -5,10 +5,19 @@
 #'
 #' `inherits(x, "data.frame")`
 #'
+#' Note that there is a similar function, [check_data()], which checks
+#' the column names, values, number of rows, and keys of a data.frame.
+#'
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_is
+#' @family id_checkers
+#'
+#' @seealso [inherits()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_data

--- a/R/chk-date.R
+++ b/R/chk-date.R
@@ -8,7 +8,14 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_scalars
+#' @family scalar_checkers
+#' @family datetime_checkers
+#'
+#' @seealso [inherits()]
+#' @seealso [length()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_date

--- a/R/chk-datetime.R
+++ b/R/chk-datetime.R
@@ -8,7 +8,14 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_scalars
+#' @family scalar_checkers
+#' @family datetime_checkers
+#'
+#' @seealso [inherits()], [length()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_date_time

--- a/R/chk-dir.R
+++ b/R/chk-dir.R
@@ -8,7 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_files
+#' @family file_checkers
+#'
+#' @seealso [vld_string()]
+#' @seealso [dir.exists()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_dir

--- a/R/chk-double.R
+++ b/R/chk-double.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_typeof
+#' @family data_type_checkers
+#'
+#' @seealso [is.double()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_double

--- a/R/chk-environment.R
+++ b/R/chk-environment.R
@@ -8,7 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_typeof
+#' @family data_type_checkers
+#'
+#' @seealso [is.environment()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_environment

--- a/R/chk-equal.R
+++ b/R/chk-equal.R
@@ -8,7 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_equals
+#' @family equal_checkers
+#'
+#' @seealso [vld_true()]
+#' @seealso [all.equal()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_equal

--- a/R/chk-equivalent.R
+++ b/R/chk-equivalent.R
@@ -8,7 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_equals
+#' @family equal_checkers
+#'
+#' @seealso [vld_true()]
+#' @seealso [all.equal()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_equivalent

--- a/R/chk-ext.R
+++ b/R/chk-ext.R
@@ -11,7 +11,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_files
+#' @family file_checkers
+#'
+#' @seealso [vld_string()]
+#' @seealso [vld_subset()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_ext

--- a/R/chk-factor.R
+++ b/R/chk-factor.R
@@ -8,7 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_typeof
+#' @family factor_checkers
+#' @family data-type_checkers
+#'
+#' @seealso [is.factor()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_factor

--- a/R/chk-false.R
+++ b/R/chk-false.R
@@ -8,7 +8,14 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_logical
+#' @family logical_checkers
+#' @family scalar_checkers
+#'
+#' @seealso [is.logical()]
+#' @seealso [length()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_false

--- a/R/chk-file.R
+++ b/R/chk-file.R
@@ -8,7 +8,14 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_files
+#' @family file_checkers
+#'
+#' @seealso [vld_string()]
+#' @seealso [file.exists()]
+#' @seealso [dir.exists()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_file

--- a/R/chk-flag.R
+++ b/R/chk-flag.R
@@ -9,10 +9,20 @@
 #'
 #' **Fail**: `logical(0)`, `c(TRUE, TRUE)`, `"TRUE"`, `1`, `NA`.
 #'
+#' Do not confuse this function with [chk_lgl()],
+#' which also checks for logical scalars of `length(x) == 1`
+#' but can include `NA`s.
+#'
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_logical
+#' @family logical_checkers
+#' @family scalar_checkers
+#'
+#' @seealso [is.logical()] [length()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_flag

--- a/R/chk-function.R
+++ b/R/chk-function.R
@@ -8,7 +8,14 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_is
+#' @family function_checkers
+#' @family ellpisis_checkers
+#' @family missing_checkers
+#'
+#' @seealso [is.function()] [formals()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_function

--- a/R/chk-gt.R
+++ b/R/chk-gt.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_ranges
+#' @family range_checkers
+#'
+#' @seealso [all()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_gt

--- a/R/chk-gte.R
+++ b/R/chk-gte.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_ranges
+#' @family range_checkers
+#'
+#' @seealso [all()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_gte

--- a/R/chk-identical.R
+++ b/R/chk-identical.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_equals
+#' @family equal_checkers
+#'
+#' @seealso [identical()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_identical

--- a/R/chk-integer.R
+++ b/R/chk-integer.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_typeof
+#' @family data_type_checkers
+#'
+#' @seealso [is.integer()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_integer

--- a/R/chk-is.R
+++ b/R/chk-is.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_is
+#' @family id_checkers
+#'
+#' @seealso [inherits()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' chk_is(1, "numeric")

--- a/R/chk-join.R
+++ b/R/chk-join.R
@@ -7,7 +7,11 @@
 #' @param y A data.frame with columns in by.
 #' @inherit params return
 #'
-#' @family chk_set
+#' @family misc_checkers
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_join

--- a/R/chk-length.R
+++ b/R/chk-length.R
@@ -8,8 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_misc
-#' @seealso [check_dim()]
+#' @family length_checkers
+#'
+#' @seealso [length()], [check_dim()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_length

--- a/R/chk-lgl.R
+++ b/R/chk-lgl.R
@@ -5,10 +5,20 @@
 #'
 #' `is.logical(x) && length(x) == 1L`
 #'
+#' If you only want to check the data type (not whether `length(x) == 1`),
+#' you should use the [chk_logical()] function.
+#'
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_logical
+#' @family logical_checkers
+#' @family scalar_checkers
+#'
+#' @seealso [is.logical()]
+#' @seealso [length()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_lgl

--- a/R/chk-list.R
+++ b/R/chk-list.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_typeof
+#' @family data_structure_checkers
+#'
+#' @seealso [is.list()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_list

--- a/R/chk-logical.R
+++ b/R/chk-logical.R
@@ -5,10 +5,20 @@
 #'
 #' `is.logical(x)`
 #'
+#' If you want to check if it is a scalar,
+#' meaning that in addition to being of logical type,
+#' it has `length(x) == 1`, you should use [chk_lgl()]
+#'
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_typeof
+#' @family logical_checkers
+#' @family data_type_checkers
+#'
+#' @seealso [is.logical()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_logical

--- a/R/chk-lt.R
+++ b/R/chk-lt.R
@@ -8,7 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_ranges
+#' @family range_checkers
+#'
+#' @seealso [all()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_lt

--- a/R/chk-lte.R
+++ b/R/chk-lte.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_ranges
+#' @family range_checkers
+#'
+#' @seealso [all()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_lte

--- a/R/chk-match.R
+++ b/R/chk-match.R
@@ -8,7 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_misc
+#' @family regex_checkers
+#'
+#' @seealso [all()]
+#' @seealso [grepl()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_match

--- a/R/chk-matrix.R
+++ b/R/chk-matrix.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_is
+#' @family data_structure_checkers
+#'
+#' @seealso [is.matrix()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_matrix

--- a/R/chk-missing.R
+++ b/R/chk-missing.R
@@ -12,7 +12,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_misc
+#' @family missing_checkers
+#'
+#' @seealso [missing()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_missing

--- a/R/chk-named.R
+++ b/R/chk-named.R
@@ -8,7 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_misc
+#' @family name_checkers
+#'
+#' @seealso [names()]
+#' @seealso [is.null()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_named

--- a/R/chk-not-any-na.R
+++ b/R/chk-not-any-na.R
@@ -12,7 +12,11 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_misc
+#' @family misc_checkers
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_not_any_na

--- a/R/chk-not-empty.R
+++ b/R/chk-not-empty.R
@@ -12,7 +12,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_misc
+#' @family misc_checkers
+#'
+#' @seealso [length()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_not_empty

--- a/R/chk-not-missing.R
+++ b/R/chk-not-missing.R
@@ -12,7 +12,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_misc
+#' @family missing_checkers
+#'
+#' @seealso [missing()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_not_missing

--- a/R/chk-not-null.R
+++ b/R/chk-not-null.R
@@ -8,7 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_nulls
+#' @family null_checkers
+#'
+#' @seealso [is.null()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_not_null

--- a/R/chk-not-subset.R
+++ b/R/chk-not-subset.R
@@ -8,7 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_set
+#' @family set_checkers
+#'
+#' @seealso [any()]
+#' @seealso [length()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_not_subset

--- a/R/chk-null.R
+++ b/R/chk-null.R
@@ -8,7 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_nulls
+#' @family null_checkers
+#'
+#' @seealso [is.null()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_null

--- a/R/chk-number.R
+++ b/R/chk-number.R
@@ -12,7 +12,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_scalars
+#' @family data_type_checkers scalar_checkers
+#'
+#' @seealso [is.numeric()]
+#' @seealso [length()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_number

--- a/R/chk-numeric.R
+++ b/R/chk-numeric.R
@@ -12,7 +12,12 @@
 #' @inheritParams chk_flag
 #' @inherit params return
 #'
-#' @family chk_is
+#' @family data_type_checkers
+#'
+#' @seealso [is.numeric()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_numeric

--- a/R/chk-orderset.R
+++ b/R/chk-orderset.R
@@ -11,7 +11,14 @@
 #'
 #' The `vld_` function returns a flag indicating whether the test was met.
 #'
-#' @family chk_set
+#' @family set_checkers
+#'
+#' @seealso [vld_equivalent()]
+#' @seealso [unique()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #' @export
 #'
 #' @examples

--- a/R/chk-range.R
+++ b/R/chk-range.R
@@ -14,7 +14,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_ranges
+#' @family range_checkers
+#'
+#' @seealso [all()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_range

--- a/R/chk-s3-class.R
+++ b/R/chk-s3-class.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_is
+#' @family id_checkers
+#'
+#' @seealso [inherits()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_s3_class

--- a/R/chk-s4-class.R
+++ b/R/chk-s4-class.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_is
+#' @family id_checkers
+#'
+#' @seealso [methods::is()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_s4_class

--- a/R/chk-scalar.R
+++ b/R/chk-scalar.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_scalars
+#' @family scalar_checkers
+#'
+#' @seealso [length()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_scalar

--- a/R/chk-setequal.R
+++ b/R/chk-setequal.R
@@ -8,7 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_set
+#' @family set_checkers
+#'
+#' @seealso [setequal()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_setequal

--- a/R/chk-sorted.R
+++ b/R/chk-sorted.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_misc
+#' @family sorted_checkers
+#'
+#' @seealso [is.unsorted()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_sorted

--- a/R/chk-string.R
+++ b/R/chk-string.R
@@ -8,7 +8,12 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_scalars
+#' @family scalar_checkers
+#'
+#' @seealso [length()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_string

--- a/R/chk-subset.R
+++ b/R/chk-subset.R
@@ -5,10 +5,19 @@
 #'
 #' `all(x %in% values)`
 #'
+#' Pay attention to the order of the arguments `value` and `x`
+#' in this function compared to [chk_superset()]
+#'
+#'
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_set
+#' @family set_checkers
+#'
+#' @seealso [all()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_subset

--- a/R/chk-superset.R
+++ b/R/chk-superset.R
@@ -5,10 +5,19 @@
 #'
 #' `all(values %in% x)`
 #'
+#' Pay attention to the order of the arguments `value` and `x`
+#' in this function compared to [chk_subset()]
+#'
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_set
+#' @family set_checkers
+#'
+#' @seealso [all()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_superset

--- a/R/chk-true.R
+++ b/R/chk-true.R
@@ -8,7 +8,14 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_logical
+#' @family logical_checkers
+#' @family scalar_checkers
+#'
+#' @seealso [is.logical()]
+#' @seealso [length()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_true

--- a/R/chk-tz.R
+++ b/R/chk-tz.R
@@ -8,7 +8,17 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_scalars
+#' @family tz_checkers
+#' @family date_checkers
+#' @family scalar_checkers
+#'
+#' @seealso [length()]
+#' @seealso [OlsonNames()]
+#' @seealso [is.character()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' chk_tz("UTC")

--- a/R/chk-unique.R
+++ b/R/chk-unique.R
@@ -8,7 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_misc
+#' @family misc_checkers
+#'
+#' @seealso [anyDuplicated()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_unique

--- a/R/chk-unused.R
+++ b/R/chk-unused.R
@@ -9,7 +9,13 @@
 #' @inherit params return
 #' @return The `chk_` function throws an informative error if the test fails.
 #'
-#' @family chk_ellipsis
+#' @family ellipsis_checkers
+#'
+#' @seealso [length()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_unused

--- a/R/chk-used.R
+++ b/R/chk-used.R
@@ -9,7 +9,12 @@
 #' @inherit params return
 #' @return The `chk_` function throws an informative error if the test fails.
 #'
-#' @family chk_ellipsis
+#' @family ellipsis_checkers
+#'
+#' @seealso [length()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_used

--- a/R/chk-valid-name.R
+++ b/R/chk-valid-name.R
@@ -8,7 +8,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_misc
+#' @family name_checkers
+#'
+#' @seealso [identical()]
+#' @seealso [make.names()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_valid_name

--- a/R/chk-vector.R
+++ b/R/chk-vector.R
@@ -12,7 +12,13 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_is
+#' @family data_structure_checkers
+#'
+#' @seealso [is.atomic()], [is.matrix()], [is.array()], [is.list()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_vector

--- a/R/chk-whole-number.R
+++ b/R/chk-whole-number.R
@@ -12,7 +12,16 @@
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_scalars
+#' @family scalar_checker
+#' @family whole_number_checkers
+#'
+#' @seealso [is.integer()]
+#' @seealso [vld_true()]
+#' @seealso [vld_number()]
+#'
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_whole_number

--- a/R/chk-whole-numeric.R
+++ b/R/chk-whole-numeric.R
@@ -5,11 +5,18 @@
 #'
 #' `is.integer(x) || (is.double(x) && vld_true(all.equal(x, as.integer(x))))`
 #'
-#'
 #' @inheritParams params
 #' @inherit params return
 #'
-#' @family chk_is
+#' @family whole_number_checkers
+#'
+#' @seealso [is.integer()]
+#' @seealso [is.double()]
+#' @seealso [vld_true()]
+#' @seealso [all.equal()]
+#' @seealso For more details about the use of this function,
+#' please read the article
+#' \href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 #'
 #' @examples
 #' # chk_whole_numeric

--- a/man/chk_all.Rd
+++ b/man/chk_all.Rd
@@ -45,9 +45,15 @@ chk_all(c(TRUE, NA), chk_lgl)
 vld_all(c(TRUE, NA), vld_lgl)
 }
 \seealso{
-Other chk_alls: 
+\code{\link[=all]{all()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other all_checkers: 
 \code{\link{chk_all_equal}()},
 \code{\link{chk_all_equivalent}()},
 \code{\link{chk_all_identical}()}
 }
-\concept{chk_alls}
+\concept{all_checkers}

--- a/man/chk_all_equal.Rd
+++ b/man/chk_all_equal.Rd
@@ -42,9 +42,25 @@ try(chk_all_equal(list(c(x = 1), c(y = 1))))
 vld_all_equal(c(1, 1L))
 }
 \seealso{
-Other chk_alls: 
+\code{\link[=length]{length()}}
+
+\code{\link[=vld_equal]{vld_equal()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other equal_checkers: 
+\code{\link{chk_all_equivalent}()},
+\code{\link{chk_all_identical}()},
+\code{\link{chk_equal}()},
+\code{\link{chk_equivalent}()},
+\code{\link{chk_identical}()}
+
+Other all_checkers: 
 \code{\link{chk_all}()},
 \code{\link{chk_all_equivalent}()},
 \code{\link{chk_all_identical}()}
 }
-\concept{chk_alls}
+\concept{all_checkers}
+\concept{equal_checkers}

--- a/man/chk_all_equivalent.Rd
+++ b/man/chk_all_equivalent.Rd
@@ -42,9 +42,25 @@ chk_all_equivalent(list(c(x = 1), c(y = 1)))
 vld_all_equivalent(c(x = 1, y = 1))
 }
 \seealso{
-Other chk_alls: 
+\code{\link[=length]{length()}}
+
+\code{\link[=vld_equivalent]{vld_equivalent()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other equal_checkers: 
+\code{\link{chk_all_equal}()},
+\code{\link{chk_all_identical}()},
+\code{\link{chk_equal}()},
+\code{\link{chk_equivalent}()},
+\code{\link{chk_identical}()}
+
+Other all_checkers: 
 \code{\link{chk_all}()},
 \code{\link{chk_all_equal}()},
 \code{\link{chk_all_identical}()}
 }
-\concept{chk_alls}
+\concept{all_checkers}
+\concept{equal_checkers}

--- a/man/chk_all_identical.Rd
+++ b/man/chk_all_identical.Rd
@@ -42,9 +42,25 @@ try(chk_all_identical(c(1, 1.1)))
 vld_all_identical(c(1, 1))
 }
 \seealso{
-Other chk_alls: 
+\code{\link[=length]{length()}}
+
+\code{\link[=vld_identical]{vld_identical()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other equal_checkers: 
+\code{\link{chk_all_equal}()},
+\code{\link{chk_all_equivalent}()},
+\code{\link{chk_equal}()},
+\code{\link{chk_equivalent}()},
+\code{\link{chk_identical}()}
+
+Other all_checkers: 
 \code{\link{chk_all}()},
 \code{\link{chk_all_equal}()},
 \code{\link{chk_all_equivalent}()}
 }
-\concept{chk_alls}
+\concept{all_checkers}
+\concept{equal_checkers}

--- a/man/chk_array.Rd
+++ b/man/chk_array.Rd
@@ -40,16 +40,16 @@ vld_array(1)
 vld_array(array(1))
 }
 \seealso{
-Other chk_is: 
+\code{\link[=is.array]{is.array()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other data_structure_checkers: 
 \code{\link{chk_atomic}()},
-\code{\link{chk_data}()},
-\code{\link{chk_function}()},
-\code{\link{chk_is}()},
+\code{\link{chk_list}()},
 \code{\link{chk_matrix}()},
-\code{\link{chk_numeric}()},
-\code{\link{chk_s3_class}()},
-\code{\link{chk_s4_class}()},
-\code{\link{chk_vector}()},
-\code{\link{chk_whole_numeric}()}
+\code{\link{chk_vector}()}
 }
-\concept{chk_is}
+\concept{data_structure_checkers}

--- a/man/chk_atomic.Rd
+++ b/man/chk_atomic.Rd
@@ -42,16 +42,16 @@ vld_atomic(list(1))
 vld_atomic(NULL)
 }
 \seealso{
-Other chk_is: 
+\code{\link[=is.atomic]{is.atomic()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other data_structure_checkers: 
 \code{\link{chk_array}()},
-\code{\link{chk_data}()},
-\code{\link{chk_function}()},
-\code{\link{chk_is}()},
+\code{\link{chk_list}()},
 \code{\link{chk_matrix}()},
-\code{\link{chk_numeric}()},
-\code{\link{chk_s3_class}()},
-\code{\link{chk_s4_class}()},
-\code{\link{chk_vector}()},
-\code{\link{chk_whole_numeric}()}
+\code{\link{chk_vector}()}
 }
-\concept{chk_is}
+\concept{data_structure_checkers}

--- a/man/chk_character.Rd
+++ b/man/chk_character.Rd
@@ -44,14 +44,18 @@ vld_character(TRUE)
 vld_character(factor("text"))
 }
 \seealso{
-Other chk_typeof: 
+\code{\link[=is.character]{is.character()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other data_type_checkers: 
 \code{\link{chk_character_or_factor}()},
-\code{\link{chk_count}()},
 \code{\link{chk_double}()},
 \code{\link{chk_environment}()},
-\code{\link{chk_factor}()},
 \code{\link{chk_integer}()},
-\code{\link{chk_list}()},
-\code{\link{chk_logical}()}
+\code{\link{chk_logical}()},
+\code{\link{chk_numeric}()}
 }
-\concept{chk_typeof}
+\concept{data_type_checkers}

--- a/man/chk_character_or_factor.Rd
+++ b/man/chk_character_or_factor.Rd
@@ -45,14 +45,24 @@ vld_character_or_factor(TRUE)
 vld_character_or_factor(factor("text"))
 }
 \seealso{
-Other chk_typeof: 
+\code{\link[=is.character]{is.character()}}
+
+\code{\link[=is.factor]{is.factor()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other data_type_checkers: 
 \code{\link{chk_character}()},
-\code{\link{chk_count}()},
 \code{\link{chk_double}()},
 \code{\link{chk_environment}()},
-\code{\link{chk_factor}()},
 \code{\link{chk_integer}()},
-\code{\link{chk_list}()},
-\code{\link{chk_logical}()}
+\code{\link{chk_logical}()},
+\code{\link{chk_numeric}()}
+
+Other factor_checkers: 
+\code{\link{chk_factor}()}
 }
-\concept{chk_typeof}
+\concept{data_type_checkers}
+\concept{factor_checkers}

--- a/man/chk_compatible_lengths.Rd
+++ b/man/chk_compatible_lengths.Rd
@@ -82,3 +82,12 @@ vld_compatible_lengths(a, b)
 b <- 1:6
 vld_compatible_lengths(a, b)
 }
+\seealso{
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other length_checkers: 
+\code{\link{chk_length}()}
+}
+\concept{length_checkers}

--- a/man/chk_count.Rd
+++ b/man/chk_count.Rd
@@ -41,14 +41,28 @@ vld_count(-1)
 vld_count(0.5)
 }
 \seealso{
-Other chk_typeof: 
-\code{\link{chk_character}()},
-\code{\link{chk_character_or_factor}()},
-\code{\link{chk_double}()},
-\code{\link{chk_environment}()},
-\code{\link{chk_factor}()},
-\code{\link{chk_integer}()},
-\code{\link{chk_list}()},
-\code{\link{chk_logical}()}
+\code{\link[=vld_whole_number]{vld_whole_number()}}
+
+\code{\link[=length]{length()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other scalar_checkers: 
+\code{\link{chk_date}()},
+\code{\link{chk_date_time}()},
+\code{\link{chk_false}()},
+\code{\link{chk_flag}()},
+\code{\link{chk_lgl}()},
+\code{\link{chk_scalar}()},
+\code{\link{chk_string}()},
+\code{\link{chk_true}()},
+\code{\link{chk_tz}()}
+
+Other whole_number_checkers: 
+\code{\link{chk_whole_number}()},
+\code{\link{chk_whole_numeric}()}
 }
-\concept{chk_typeof}
+\concept{scalar_checkers}
+\concept{whole_number_checkers}

--- a/man/chk_data.Rd
+++ b/man/chk_data.Rd
@@ -24,6 +24,9 @@ The \code{vld_} function returns a flag indicating whether the test was met.
 Checks data.frame using
 
 \code{inherits(x, "data.frame")}
+
+Note that there is a similar function, \code{\link[=check_data]{check_data()}}, which checks
+the column names, values, number of rows, and keys of a data.frame.
 }
 \section{Functions}{
 \itemize{
@@ -40,16 +43,15 @@ vld_data(data.frame(x = 1))
 vld_data(c(x = 1))
 }
 \seealso{
-Other chk_is: 
-\code{\link{chk_array}()},
-\code{\link{chk_atomic}()},
-\code{\link{chk_function}()},
+\code{\link[=inherits]{inherits()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other id_checkers: 
 \code{\link{chk_is}()},
-\code{\link{chk_matrix}()},
-\code{\link{chk_numeric}()},
 \code{\link{chk_s3_class}()},
-\code{\link{chk_s4_class}()},
-\code{\link{chk_vector}()},
-\code{\link{chk_whole_numeric}()}
+\code{\link{chk_s4_class}()}
 }
-\concept{chk_is}
+\concept{id_checkers}

--- a/man/chk_date.Rd
+++ b/man/chk_date.Rd
@@ -40,12 +40,27 @@ vld_date(Sys.time())
 vld_date(1)
 }
 \seealso{
-Other chk_scalars: 
+\code{\link[=inherits]{inherits()}}
+
+\code{\link[=length]{length()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other scalar_checkers: 
+\code{\link{chk_count}()},
 \code{\link{chk_date_time}()},
-\code{\link{chk_number}()},
+\code{\link{chk_false}()},
+\code{\link{chk_flag}()},
+\code{\link{chk_lgl}()},
 \code{\link{chk_scalar}()},
 \code{\link{chk_string}()},
-\code{\link{chk_tz}()},
-\code{\link{chk_whole_number}()}
+\code{\link{chk_true}()},
+\code{\link{chk_tz}()}
+
+Other datetime_checkers: 
+\code{\link{chk_date_time}()}
 }
-\concept{chk_scalars}
+\concept{datetime_checkers}
+\concept{scalar_checkers}

--- a/man/chk_date_time.Rd
+++ b/man/chk_date_time.Rd
@@ -56,12 +56,25 @@ vld_date_time("2001-01-02")
 vld_date_time(c(Sys.time(), Sys.time()))
 }
 \seealso{
-Other chk_scalars: 
+\code{\link[=inherits]{inherits()}}, \code{\link[=length]{length()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other scalar_checkers: 
+\code{\link{chk_count}()},
 \code{\link{chk_date}()},
-\code{\link{chk_number}()},
+\code{\link{chk_false}()},
+\code{\link{chk_flag}()},
+\code{\link{chk_lgl}()},
 \code{\link{chk_scalar}()},
 \code{\link{chk_string}()},
-\code{\link{chk_tz}()},
-\code{\link{chk_whole_number}()}
+\code{\link{chk_true}()},
+\code{\link{chk_tz}()}
+
+Other datetime_checkers: 
+\code{\link{chk_date}()}
 }
-\concept{chk_scalars}
+\concept{datetime_checkers}
+\concept{scalar_checkers}

--- a/man/chk_dir.Rd
+++ b/man/chk_dir.Rd
@@ -40,8 +40,16 @@ vld_dir(tempdir())
 vld_dir(tempfile())
 }
 \seealso{
-Other chk_files: 
+\code{\link[=vld_string]{vld_string()}}
+
+\code{\link[=dir.exists]{dir.exists()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other file_checkers: 
 \code{\link{chk_ext}()},
 \code{\link{chk_file}()}
 }
-\concept{chk_files}
+\concept{file_checkers}

--- a/man/chk_double.Rd
+++ b/man/chk_double.Rd
@@ -44,14 +44,18 @@ vld_double(1L)
 vld_double(TRUE)
 }
 \seealso{
-Other chk_typeof: 
+\code{\link[=is.double]{is.double()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other data_type_checkers: 
 \code{\link{chk_character}()},
 \code{\link{chk_character_or_factor}()},
-\code{\link{chk_count}()},
 \code{\link{chk_environment}()},
-\code{\link{chk_factor}()},
 \code{\link{chk_integer}()},
-\code{\link{chk_list}()},
-\code{\link{chk_logical}()}
+\code{\link{chk_logical}()},
+\code{\link{chk_numeric}()}
 }
-\concept{chk_typeof}
+\concept{data_type_checkers}

--- a/man/chk_environment.Rd
+++ b/man/chk_environment.Rd
@@ -41,14 +41,18 @@ vld_environment(.GlobalEnv)
 vld_environment(environment())
 }
 \seealso{
-Other chk_typeof: 
+\code{\link[=is.environment]{is.environment()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other data_type_checkers: 
 \code{\link{chk_character}()},
 \code{\link{chk_character_or_factor}()},
-\code{\link{chk_count}()},
 \code{\link{chk_double}()},
-\code{\link{chk_factor}()},
 \code{\link{chk_integer}()},
-\code{\link{chk_list}()},
-\code{\link{chk_logical}()}
+\code{\link{chk_logical}()},
+\code{\link{chk_numeric}()}
 }
-\concept{chk_typeof}
+\concept{data_type_checkers}

--- a/man/chk_equal.Rd
+++ b/man/chk_equal.Rd
@@ -44,8 +44,19 @@ try(chk_equal(c(x = 1), c(y = 1L)))
 vld_equal(1, 1.00000001)
 }
 \seealso{
-Other chk_equals: 
+\code{\link[=vld_true]{vld_true()}}
+
+\code{\link[=all.equal]{all.equal()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other equal_checkers: 
+\code{\link{chk_all_equal}()},
+\code{\link{chk_all_equivalent}()},
+\code{\link{chk_all_identical}()},
 \code{\link{chk_equivalent}()},
 \code{\link{chk_identical}()}
 }
-\concept{chk_equals}
+\concept{equal_checkers}

--- a/man/chk_equivalent.Rd
+++ b/man/chk_equivalent.Rd
@@ -43,8 +43,19 @@ chk_equivalent(c(x = 1), c(y = 1))
 vld_equivalent(c(x = 1), c(y = 1L))
 }
 \seealso{
-Other chk_equals: 
+\code{\link[=vld_true]{vld_true()}}
+
+\code{\link[=all.equal]{all.equal()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other equal_checkers: 
+\code{\link{chk_all_equal}()},
+\code{\link{chk_all_equivalent}()},
+\code{\link{chk_all_identical}()},
 \code{\link{chk_equal}()},
 \code{\link{chk_identical}()}
 }
-\concept{chk_equals}
+\concept{equal_checkers}

--- a/man/chk_ext.Rd
+++ b/man/chk_ext.Rd
@@ -44,8 +44,16 @@ vld_ext("oeu.pdf", "pdf")
 vld_ext(toupper("oeu.pdf"), "PDF")
 }
 \seealso{
-Other chk_files: 
+\code{\link[=vld_string]{vld_string()}}
+
+\code{\link[=vld_subset]{vld_subset()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other file_checkers: 
 \code{\link{chk_dir}()},
 \code{\link{chk_file}()}
 }
-\concept{chk_files}
+\concept{file_checkers}

--- a/man/chk_factor.Rd
+++ b/man/chk_factor.Rd
@@ -41,14 +41,14 @@ vld_factor("1")
 vld_factor(1L)
 }
 \seealso{
-Other chk_typeof: 
-\code{\link{chk_character}()},
-\code{\link{chk_character_or_factor}()},
-\code{\link{chk_count}()},
-\code{\link{chk_double}()},
-\code{\link{chk_environment}()},
-\code{\link{chk_integer}()},
-\code{\link{chk_list}()},
-\code{\link{chk_logical}()}
+\code{\link[=is.factor]{is.factor()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other factor_checkers: 
+\code{\link{chk_character_or_factor}()}
 }
-\concept{chk_typeof}
+\concept{data-type_checkers}
+\concept{factor_checkers}

--- a/man/chk_false.Rd
+++ b/man/chk_false.Rd
@@ -42,9 +42,30 @@ vld_false(0)
 vld_false(c(FALSE, FALSE))
 }
 \seealso{
-Other chk_logical: 
+\code{\link[=is.logical]{is.logical()}}
+
+\code{\link[=length]{length()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other logical_checkers: 
 \code{\link{chk_flag}()},
 \code{\link{chk_lgl}()},
+\code{\link{chk_logical}()},
 \code{\link{chk_true}()}
+
+Other scalar_checkers: 
+\code{\link{chk_count}()},
+\code{\link{chk_date}()},
+\code{\link{chk_date_time}()},
+\code{\link{chk_flag}()},
+\code{\link{chk_lgl}()},
+\code{\link{chk_scalar}()},
+\code{\link{chk_string}()},
+\code{\link{chk_true}()},
+\code{\link{chk_tz}()}
 }
-\concept{chk_logical}
+\concept{logical_checkers}
+\concept{scalar_checkers}

--- a/man/chk_file.Rd
+++ b/man/chk_file.Rd
@@ -37,8 +37,18 @@ try(chk_file(tempfile()))
 vld_file(tempfile())
 }
 \seealso{
-Other chk_files: 
+\code{\link[=vld_string]{vld_string()}}
+
+\code{\link[=file.exists]{file.exists()}}
+
+\code{\link[=dir.exists]{dir.exists()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other file_checkers: 
 \code{\link{chk_dir}()},
 \code{\link{chk_ext}()}
 }
-\concept{chk_files}
+\concept{file_checkers}

--- a/man/chk_flag.Rd
+++ b/man/chk_flag.Rd
@@ -28,6 +28,10 @@ Checks if non-missing logical scalar using
 \strong{Pass}: \code{TRUE}, \code{FALSE}.
 
 \strong{Fail}: \code{logical(0)}, \code{c(TRUE, TRUE)}, \code{"TRUE"}, \code{1}, \code{NA}.
+
+Do not confuse this function with \code{\link[=chk_lgl]{chk_lgl()}},
+which also checks for logical scalars of \code{length(x) == 1}
+but can include \code{NA}s.
 }
 \section{Functions}{
 \itemize{
@@ -43,9 +47,28 @@ vld_flag(TRUE)
 vld_flag(1)
 }
 \seealso{
-Other chk_logical: 
+\code{\link[=is.logical]{is.logical()}} \code{\link[=length]{length()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other logical_checkers: 
 \code{\link{chk_false}()},
 \code{\link{chk_lgl}()},
+\code{\link{chk_logical}()},
 \code{\link{chk_true}()}
+
+Other scalar_checkers: 
+\code{\link{chk_count}()},
+\code{\link{chk_date}()},
+\code{\link{chk_date_time}()},
+\code{\link{chk_false}()},
+\code{\link{chk_lgl}()},
+\code{\link{chk_scalar}()},
+\code{\link{chk_string}()},
+\code{\link{chk_true}()},
+\code{\link{chk_tz}()}
 }
-\concept{chk_logical}
+\concept{logical_checkers}
+\concept{scalar_checkers}

--- a/man/chk_function.Rd
+++ b/man/chk_function.Rd
@@ -43,16 +43,16 @@ vld_function(1)
 vld_function(list(1))
 }
 \seealso{
-Other chk_is: 
-\code{\link{chk_array}()},
-\code{\link{chk_atomic}()},
-\code{\link{chk_data}()},
-\code{\link{chk_is}()},
-\code{\link{chk_matrix}()},
-\code{\link{chk_numeric}()},
-\code{\link{chk_s3_class}()},
-\code{\link{chk_s4_class}()},
-\code{\link{chk_vector}()},
-\code{\link{chk_whole_numeric}()}
+\code{\link[=is.function]{is.function()}} \code{\link[=formals]{formals()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other missing_checkers: 
+\code{\link{chk_missing}()},
+\code{\link{chk_not_missing}()}
 }
-\concept{chk_is}
+\concept{ellpisis_checkers}
+\concept{function_checkers}
+\concept{missing_checkers}

--- a/man/chk_gt.Rd
+++ b/man/chk_gt.Rd
@@ -46,10 +46,16 @@ vld_gt(c(-0.1, 0.2), value = -1)
 vld_gt("b", value = "a")
 }
 \seealso{
-Other chk_ranges: 
+\code{\link[=all]{all()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other range_checkers: 
 \code{\link{chk_gte}()},
 \code{\link{chk_lt}()},
 \code{\link{chk_lte}()},
 \code{\link{chk_range}()}
 }
-\concept{chk_ranges}
+\concept{range_checkers}

--- a/man/chk_gte.Rd
+++ b/man/chk_gte.Rd
@@ -44,10 +44,16 @@ vld_gte(c(0.1, 0.2, NA))
 vld_gte(c(0.1, 0.2, NA), value = 1)
 }
 \seealso{
-Other chk_ranges: 
+\code{\link[=all]{all()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other range_checkers: 
 \code{\link{chk_gt}()},
 \code{\link{chk_lt}()},
 \code{\link{chk_lte}()},
 \code{\link{chk_range}()}
 }
-\concept{chk_ranges}
+\concept{range_checkers}

--- a/man/chk_identical.Rd
+++ b/man/chk_identical.Rd
@@ -41,8 +41,17 @@ try(chk_identical(1, c(1, 1)))
 vld_identical(1, 1)
 }
 \seealso{
-Other chk_equals: 
+\code{\link[=identical]{identical()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other equal_checkers: 
+\code{\link{chk_all_equal}()},
+\code{\link{chk_all_equivalent}()},
+\code{\link{chk_all_identical}()},
 \code{\link{chk_equal}()},
 \code{\link{chk_equivalent}()}
 }
-\concept{chk_equals}
+\concept{equal_checkers}

--- a/man/chk_integer.Rd
+++ b/man/chk_integer.Rd
@@ -43,14 +43,18 @@ vld_integer(1)
 vld_integer(TRUE)
 }
 \seealso{
-Other chk_typeof: 
+\code{\link[=is.integer]{is.integer()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other data_type_checkers: 
 \code{\link{chk_character}()},
 \code{\link{chk_character_or_factor}()},
-\code{\link{chk_count}()},
 \code{\link{chk_double}()},
 \code{\link{chk_environment}()},
-\code{\link{chk_factor}()},
-\code{\link{chk_list}()},
-\code{\link{chk_logical}()}
+\code{\link{chk_logical}()},
+\code{\link{chk_numeric}()}
 }
-\concept{chk_typeof}
+\concept{data_type_checkers}

--- a/man/chk_is.Rd
+++ b/man/chk_is.Rd
@@ -41,16 +41,15 @@ vld_is(numeric(0), "numeric")
 vld_is(1L, "double")
 }
 \seealso{
-Other chk_is: 
-\code{\link{chk_array}()},
-\code{\link{chk_atomic}()},
+\code{\link[=inherits]{inherits()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other id_checkers: 
 \code{\link{chk_data}()},
-\code{\link{chk_function}()},
-\code{\link{chk_matrix}()},
-\code{\link{chk_numeric}()},
 \code{\link{chk_s3_class}()},
-\code{\link{chk_s4_class}()},
-\code{\link{chk_vector}()},
-\code{\link{chk_whole_numeric}()}
+\code{\link{chk_s4_class}()}
 }
-\concept{chk_is}
+\concept{id_checkers}

--- a/man/chk_join.Rd
+++ b/man/chk_join.Rd
@@ -44,11 +44,13 @@ vld_join(data.frame(z = 1), data.frame(a = 1:2), by = c(z = "a"))
 vld_join(data.frame(z = 1), data.frame(a = 2), by = c(z = "a"))
 }
 \seealso{
-Other chk_set: 
-\code{\link{chk_not_subset}()},
-\code{\link{chk_orderset}()},
-\code{\link{chk_superset}()},
-\code{\link{vld_not_subset}()},
-\code{\link{vld_orderset}()}
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other misc_checkers: 
+\code{\link{chk_not_any_na}()},
+\code{\link{chk_not_empty}()},
+\code{\link{chk_unique}()}
 }
-\concept{chk_set}
+\concept{misc_checkers}

--- a/man/chk_length.Rd
+++ b/man/chk_length.Rd
@@ -43,17 +43,13 @@ vld_length(2:1, 2)
 vld_length(2:1, 1)
 }
 \seealso{
-\code{\link[=check_dim]{check_dim()}}
+\code{\link[=length]{length()}}, \code{\link[=check_dim]{check_dim()}}
 
-Other chk_misc: 
-\code{\link{chk_match}()},
-\code{\link{chk_missing}()},
-\code{\link{chk_named}()},
-\code{\link{chk_not_any_na}()},
-\code{\link{chk_not_empty}()},
-\code{\link{chk_not_missing}()},
-\code{\link{chk_sorted}()},
-\code{\link{chk_unique}()},
-\code{\link{chk_valid_name}()}
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other length_checkers: 
+\code{\link{chk_compatible_lengths}()}
 }
-\concept{chk_misc}
+\concept{length_checkers}

--- a/man/chk_lgl.Rd
+++ b/man/chk_lgl.Rd
@@ -24,6 +24,9 @@ The \code{vld_} function returns a flag indicating whether the test was met.
 Checks if logical scalar using
 
 \code{is.logical(x) && length(x) == 1L}
+
+If you only want to check the data type (not whether \code{length(x) == 1}),
+you should use the \code{\link[=chk_logical]{chk_logical()}} function.
 }
 \section{Functions}{
 \itemize{
@@ -42,9 +45,30 @@ vld_lgl(1)
 vld_lgl(c(TRUE, TRUE))
 }
 \seealso{
-Other chk_logical: 
+\code{\link[=is.logical]{is.logical()}}
+
+\code{\link[=length]{length()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other logical_checkers: 
 \code{\link{chk_false}()},
 \code{\link{chk_flag}()},
+\code{\link{chk_logical}()},
 \code{\link{chk_true}()}
+
+Other scalar_checkers: 
+\code{\link{chk_count}()},
+\code{\link{chk_date}()},
+\code{\link{chk_date_time}()},
+\code{\link{chk_false}()},
+\code{\link{chk_flag}()},
+\code{\link{chk_scalar}()},
+\code{\link{chk_string}()},
+\code{\link{chk_true}()},
+\code{\link{chk_tz}()}
 }
-\concept{chk_logical}
+\concept{logical_checkers}
+\concept{scalar_checkers}

--- a/man/chk_list.Rd
+++ b/man/chk_list.Rd
@@ -42,14 +42,16 @@ vld_list(1)
 vld_list(NULL)
 }
 \seealso{
-Other chk_typeof: 
-\code{\link{chk_character}()},
-\code{\link{chk_character_or_factor}()},
-\code{\link{chk_count}()},
-\code{\link{chk_double}()},
-\code{\link{chk_environment}()},
-\code{\link{chk_factor}()},
-\code{\link{chk_integer}()},
-\code{\link{chk_logical}()}
+\code{\link[=is.list]{is.list()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other data_structure_checkers: 
+\code{\link{chk_array}()},
+\code{\link{chk_atomic}()},
+\code{\link{chk_matrix}()},
+\code{\link{chk_vector}()}
 }
-\concept{chk_typeof}
+\concept{data_structure_checkers}

--- a/man/chk_logical.Rd
+++ b/man/chk_logical.Rd
@@ -24,6 +24,10 @@ The \code{vld_} function returns a flag indicating whether the test was met.
 Checks if logical using
 
 \code{is.logical(x)}
+
+If you want to check if it is a scalar,
+meaning that in addition to being of logical type,
+it has \code{length(x) == 1}, you should use \code{\link[=chk_lgl]{chk_lgl()}}
 }
 \section{Functions}{
 \itemize{
@@ -43,14 +47,25 @@ vld_logical(1)
 vld_logical("TRUE")
 }
 \seealso{
-Other chk_typeof: 
+\code{\link[=is.logical]{is.logical()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other logical_checkers: 
+\code{\link{chk_false}()},
+\code{\link{chk_flag}()},
+\code{\link{chk_lgl}()},
+\code{\link{chk_true}()}
+
+Other data_type_checkers: 
 \code{\link{chk_character}()},
 \code{\link{chk_character_or_factor}()},
-\code{\link{chk_count}()},
 \code{\link{chk_double}()},
 \code{\link{chk_environment}()},
-\code{\link{chk_factor}()},
 \code{\link{chk_integer}()},
-\code{\link{chk_list}()}
+\code{\link{chk_numeric}()}
 }
-\concept{chk_typeof}
+\concept{data_type_checkers}
+\concept{logical_checkers}

--- a/man/chk_lt.Rd
+++ b/man/chk_lt.Rd
@@ -46,10 +46,16 @@ vld_lt(c(-0.1, 0.2), value = 1)
 vld_lt("a", value = "b")
 }
 \seealso{
-Other chk_ranges: 
+\code{\link[=all]{all()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other range_checkers: 
 \code{\link{chk_gt}()},
 \code{\link{chk_gte}()},
 \code{\link{chk_lte}()},
 \code{\link{chk_range}()}
 }
-\concept{chk_ranges}
+\concept{range_checkers}

--- a/man/chk_lte.Rd
+++ b/man/chk_lte.Rd
@@ -44,10 +44,16 @@ vld_lte(c(-0.1, -0.2, NA))
 vld_lte(c(-0.1, -0.2, NA), value = -1)
 }
 \seealso{
-Other chk_ranges: 
+\code{\link[=all]{all()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other range_checkers: 
 \code{\link{chk_gt}()},
 \code{\link{chk_gte}()},
 \code{\link{chk_lt}()},
 \code{\link{chk_range}()}
 }
-\concept{chk_ranges}
+\concept{range_checkers}

--- a/man/chk_match.Rd
+++ b/man/chk_match.Rd
@@ -44,15 +44,12 @@ vld_match("1", regexp = "2")
 vld_match(NA_character_, regexp = ".*")
 }
 \seealso{
-Other chk_misc: 
-\code{\link{chk_length}()},
-\code{\link{chk_missing}()},
-\code{\link{chk_named}()},
-\code{\link{chk_not_any_na}()},
-\code{\link{chk_not_empty}()},
-\code{\link{chk_not_missing}()},
-\code{\link{chk_sorted}()},
-\code{\link{chk_unique}()},
-\code{\link{chk_valid_name}()}
+\code{\link[=all]{all()}}
+
+\code{\link[=grepl]{grepl()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 }
-\concept{chk_misc}
+\concept{regex_checkers}

--- a/man/chk_matrix.Rd
+++ b/man/chk_matrix.Rd
@@ -39,16 +39,16 @@ vld_matrix(1)
 vld_matrix(matrix(1))
 }
 \seealso{
-Other chk_is: 
+\code{\link[=is.matrix]{is.matrix()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other data_structure_checkers: 
 \code{\link{chk_array}()},
 \code{\link{chk_atomic}()},
-\code{\link{chk_data}()},
-\code{\link{chk_function}()},
-\code{\link{chk_is}()},
-\code{\link{chk_numeric}()},
-\code{\link{chk_s3_class}()},
-\code{\link{chk_s4_class}()},
-\code{\link{chk_vector}()},
-\code{\link{chk_whole_numeric}()}
+\code{\link{chk_list}()},
+\code{\link{chk_vector}()}
 }
-\concept{chk_is}
+\concept{data_structure_checkers}

--- a/man/chk_missing.Rd
+++ b/man/chk_missing.Rd
@@ -49,15 +49,14 @@ fun()
 fun(1)
 }
 \seealso{
-Other chk_misc: 
-\code{\link{chk_length}()},
-\code{\link{chk_match}()},
-\code{\link{chk_named}()},
-\code{\link{chk_not_any_na}()},
-\code{\link{chk_not_empty}()},
-\code{\link{chk_not_missing}()},
-\code{\link{chk_sorted}()},
-\code{\link{chk_unique}()},
-\code{\link{chk_valid_name}()}
+\code{\link[=missing]{missing()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other missing_checkers: 
+\code{\link{chk_function}()},
+\code{\link{chk_not_missing}()}
 }
-\concept{chk_misc}
+\concept{missing_checkers}

--- a/man/chk_named.Rd
+++ b/man/chk_named.Rd
@@ -43,15 +43,15 @@ vld_named(1)
 vld_named(list(1))
 }
 \seealso{
-Other chk_misc: 
-\code{\link{chk_length}()},
-\code{\link{chk_match}()},
-\code{\link{chk_missing}()},
-\code{\link{chk_not_any_na}()},
-\code{\link{chk_not_empty}()},
-\code{\link{chk_not_missing}()},
-\code{\link{chk_sorted}()},
-\code{\link{chk_unique}()},
+\code{\link[=names]{names()}}
+
+\code{\link[=is.null]{is.null()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other name_checkers: 
 \code{\link{chk_valid_name}()}
 }
-\concept{chk_misc}
+\concept{name_checkers}

--- a/man/chk_not_any_na.Rd
+++ b/man/chk_not_any_na.Rd
@@ -47,15 +47,13 @@ vld_not_any_na(c(NA, 1))
 vld_not_any_na(TRUE)
 }
 \seealso{
-Other chk_misc: 
-\code{\link{chk_length}()},
-\code{\link{chk_match}()},
-\code{\link{chk_missing}()},
-\code{\link{chk_named}()},
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other misc_checkers: 
+\code{\link{chk_join}()},
 \code{\link{chk_not_empty}()},
-\code{\link{chk_not_missing}()},
-\code{\link{chk_sorted}()},
-\code{\link{chk_unique}()},
-\code{\link{chk_valid_name}()}
+\code{\link{chk_unique}()}
 }
-\concept{chk_misc}
+\concept{misc_checkers}

--- a/man/chk_not_empty.Rd
+++ b/man/chk_not_empty.Rd
@@ -47,15 +47,15 @@ vld_not_empty(NULL)
 vld_not_empty(list())
 }
 \seealso{
-Other chk_misc: 
-\code{\link{chk_length}()},
-\code{\link{chk_match}()},
-\code{\link{chk_missing}()},
-\code{\link{chk_named}()},
+\code{\link[=length]{length()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other misc_checkers: 
+\code{\link{chk_join}()},
 \code{\link{chk_not_any_na}()},
-\code{\link{chk_not_missing}()},
-\code{\link{chk_sorted}()},
-\code{\link{chk_unique}()},
-\code{\link{chk_valid_name}()}
+\code{\link{chk_unique}()}
 }
-\concept{chk_misc}
+\concept{misc_checkers}

--- a/man/chk_not_missing.Rd
+++ b/man/chk_not_missing.Rd
@@ -49,15 +49,14 @@ fun()
 fun(1)
 }
 \seealso{
-Other chk_misc: 
-\code{\link{chk_length}()},
-\code{\link{chk_match}()},
-\code{\link{chk_missing}()},
-\code{\link{chk_named}()},
-\code{\link{chk_not_any_na}()},
-\code{\link{chk_not_empty}()},
-\code{\link{chk_sorted}()},
-\code{\link{chk_unique}()},
-\code{\link{chk_valid_name}()}
+\code{\link[=missing]{missing()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other missing_checkers: 
+\code{\link{chk_function}()},
+\code{\link{chk_missing}()}
 }
-\concept{chk_misc}
+\concept{missing_checkers}

--- a/man/chk_not_null.Rd
+++ b/man/chk_not_null.Rd
@@ -39,7 +39,13 @@ vld_not_null(1)
 vld_not_null(NULL)
 }
 \seealso{
-Other chk_nulls: 
+\code{\link[=is.null]{is.null()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other null_checkers: 
 \code{\link{chk_null}()}
 }
-\concept{chk_nulls}
+\concept{null_checkers}

--- a/man/chk_not_subset.Rd
+++ b/man/chk_not_subset.Rd
@@ -30,11 +30,18 @@ chk_not_subset(11, 1:10)
 try(chk_not_subset(1, 1:10))
 }
 \seealso{
-Other chk_set: 
-\code{\link{chk_join}()},
+\code{\link[=any]{any()}}
+
+\code{\link[=length]{length()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other set_checkers: 
 \code{\link{chk_orderset}()},
 \code{\link{chk_superset}()},
 \code{\link{vld_not_subset}()},
 \code{\link{vld_orderset}()}
 }
-\concept{chk_set}
+\concept{set_checkers}

--- a/man/chk_null.Rd
+++ b/man/chk_null.Rd
@@ -39,7 +39,13 @@ vld_null(NULL)
 vld_null(1)
 }
 \seealso{
-Other chk_nulls: 
+\code{\link[=is.null]{is.null()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other null_checkers: 
 \code{\link{chk_not_null}()}
 }
-\concept{chk_nulls}
+\concept{null_checkers}

--- a/man/chk_number.Rd
+++ b/man/chk_number.Rd
@@ -42,12 +42,12 @@ try(chk_number(TRUE))
 vld_number(1.1)
 }
 \seealso{
-Other chk_scalars: 
-\code{\link{chk_date}()},
-\code{\link{chk_date_time}()},
-\code{\link{chk_scalar}()},
-\code{\link{chk_string}()},
-\code{\link{chk_tz}()},
-\code{\link{chk_whole_number}()}
+\code{\link[=is.numeric]{is.numeric()}}
+
+\code{\link[=length]{length()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 }
-\concept{chk_scalars}
+\concept{data_type_checkers scalar_checkers}

--- a/man/chk_numeric.Rd
+++ b/man/chk_numeric.Rd
@@ -47,16 +47,18 @@ vld_numeric("1")
 vld_numeric(TRUE)
 }
 \seealso{
-Other chk_is: 
-\code{\link{chk_array}()},
-\code{\link{chk_atomic}()},
-\code{\link{chk_data}()},
-\code{\link{chk_function}()},
-\code{\link{chk_is}()},
-\code{\link{chk_matrix}()},
-\code{\link{chk_s3_class}()},
-\code{\link{chk_s4_class}()},
-\code{\link{chk_vector}()},
-\code{\link{chk_whole_numeric}()}
+\code{\link[=is.numeric]{is.numeric()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other data_type_checkers: 
+\code{\link{chk_character}()},
+\code{\link{chk_character_or_factor}()},
+\code{\link{chk_double}()},
+\code{\link{chk_environment}()},
+\code{\link{chk_integer}()},
+\code{\link{chk_logical}()}
 }
-\concept{chk_is}
+\concept{data_type_checkers}

--- a/man/chk_orderset.Rd
+++ b/man/chk_orderset.Rd
@@ -30,11 +30,18 @@ chk_orderset(1:2, 1:2)
 try(chk_orderset(2:1, 1:2))
 }
 \seealso{
-Other chk_set: 
-\code{\link{chk_join}()},
+\code{\link[=vld_equivalent]{vld_equivalent()}}
+
+\code{\link[=unique]{unique()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other set_checkers: 
 \code{\link{chk_not_subset}()},
 \code{\link{chk_superset}()},
 \code{\link{vld_not_subset}()},
 \code{\link{vld_orderset}()}
 }
-\concept{chk_set}
+\concept{set_checkers}

--- a/man/chk_range.Rd
+++ b/man/chk_range.Rd
@@ -53,10 +53,16 @@ vld_range(c(0.1, 0.2, NA))
 vld_range(c(0.1, 0.2, NA), range = c(0, 1))
 }
 \seealso{
-Other chk_ranges: 
+\code{\link[=all]{all()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other range_checkers: 
 \code{\link{chk_gt}()},
 \code{\link{chk_gte}()},
 \code{\link{chk_lt}()},
 \code{\link{chk_lte}()}
 }
-\concept{chk_ranges}
+\concept{range_checkers}

--- a/man/chk_s3_class.Rd
+++ b/man/chk_s3_class.Rd
@@ -41,16 +41,15 @@ vld_s3_class(numeric(0), "numeric")
 vld_s3_class(getClass("MethodDefinition"), "classRepresentation")
 }
 \seealso{
-Other chk_is: 
-\code{\link{chk_array}()},
-\code{\link{chk_atomic}()},
+\code{\link[=inherits]{inherits()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other id_checkers: 
 \code{\link{chk_data}()},
-\code{\link{chk_function}()},
 \code{\link{chk_is}()},
-\code{\link{chk_matrix}()},
-\code{\link{chk_numeric}()},
-\code{\link{chk_s4_class}()},
-\code{\link{chk_vector}()},
-\code{\link{chk_whole_numeric}()}
+\code{\link{chk_s4_class}()}
 }
-\concept{chk_is}
+\concept{id_checkers}

--- a/man/chk_s4_class.Rd
+++ b/man/chk_s4_class.Rd
@@ -41,16 +41,15 @@ vld_s4_class(numeric(0), "numeric")
 vld_s4_class(getClass("MethodDefinition"), "classRepresentation")
 }
 \seealso{
-Other chk_is: 
-\code{\link{chk_array}()},
-\code{\link{chk_atomic}()},
+\code{\link[methods:is]{methods::is()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other id_checkers: 
 \code{\link{chk_data}()},
-\code{\link{chk_function}()},
 \code{\link{chk_is}()},
-\code{\link{chk_matrix}()},
-\code{\link{chk_numeric}()},
-\code{\link{chk_s3_class}()},
-\code{\link{chk_vector}()},
-\code{\link{chk_whole_numeric}()}
+\code{\link{chk_s3_class}()}
 }
-\concept{chk_is}
+\concept{id_checkers}

--- a/man/chk_scalar.Rd
+++ b/man/chk_scalar.Rd
@@ -39,12 +39,21 @@ try(chk_scalar(1:2))
 vld_scalar(1)
 }
 \seealso{
-Other chk_scalars: 
+\code{\link[=length]{length()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other scalar_checkers: 
+\code{\link{chk_count}()},
 \code{\link{chk_date}()},
 \code{\link{chk_date_time}()},
-\code{\link{chk_number}()},
+\code{\link{chk_false}()},
+\code{\link{chk_flag}()},
+\code{\link{chk_lgl}()},
 \code{\link{chk_string}()},
-\code{\link{chk_tz}()},
-\code{\link{chk_whole_number}()}
+\code{\link{chk_true}()},
+\code{\link{chk_tz}()}
 }
-\concept{chk_scalars}
+\concept{scalar_checkers}

--- a/man/chk_setequal.Rd
+++ b/man/chk_setequal.Rd
@@ -54,11 +54,16 @@ vld_setequal(1, 2:1)
 vld_setequal(1:2, 2)
 }
 \seealso{
-Other chk_set: 
-\code{\link{chk_join}()},
+\code{\link[=setequal]{setequal()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other set_checkers: 
 \code{\link{chk_not_subset}()},
 \code{\link{chk_orderset}()},
 \code{\link{chk_superset}()},
 \code{\link{vld_not_subset}()}
 }
-\concept{chk_set}
+\concept{set_checkers}

--- a/man/chk_sorted.Rd
+++ b/man/chk_sorted.Rd
@@ -39,15 +39,10 @@ vld_sorted(1:2)
 vld_sorted(2:1)
 }
 \seealso{
-Other chk_misc: 
-\code{\link{chk_length}()},
-\code{\link{chk_match}()},
-\code{\link{chk_missing}()},
-\code{\link{chk_named}()},
-\code{\link{chk_not_any_na}()},
-\code{\link{chk_not_empty}()},
-\code{\link{chk_not_missing}()},
-\code{\link{chk_unique}()},
-\code{\link{chk_valid_name}()}
+\code{\link[=is.unsorted]{is.unsorted()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
 }
-\concept{chk_misc}
+\concept{sorted_checkers}

--- a/man/chk_string.Rd
+++ b/man/chk_string.Rd
@@ -42,12 +42,21 @@ vld_string(NA_character_)
 vld_string(c("1", "1"))
 }
 \seealso{
-Other chk_scalars: 
+\code{\link[=length]{length()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other scalar_checkers: 
+\code{\link{chk_count}()},
 \code{\link{chk_date}()},
 \code{\link{chk_date_time}()},
-\code{\link{chk_number}()},
+\code{\link{chk_false}()},
+\code{\link{chk_flag}()},
+\code{\link{chk_lgl}()},
 \code{\link{chk_scalar}()},
-\code{\link{chk_tz}()},
-\code{\link{chk_whole_number}()}
+\code{\link{chk_true}()},
+\code{\link{chk_tz}()}
 }
-\concept{chk_scalars}
+\concept{scalar_checkers}

--- a/man/chk_subset.Rd
+++ b/man/chk_subset.Rd
@@ -29,6 +29,9 @@ The \code{vld_} function returns a flag indicating whether the test was met.
 Checks if all values in values using
 
 \code{all(x \%in\% values)}
+
+Pay attention to the order of the arguments \code{value} and \code{x}
+in this function compared to \code{\link[=chk_superset]{chk_superset()}}
 }
 \section{Functions}{
 \itemize{
@@ -51,11 +54,16 @@ vld_subset(1, 1:10)
 vld_subset(11, 1:10)
 }
 \seealso{
-Other chk_set: 
-\code{\link{chk_join}()},
+\code{\link[=all]{all()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other set_checkers: 
 \code{\link{chk_not_subset}()},
 \code{\link{chk_orderset}()},
 \code{\link{chk_superset}()},
 \code{\link{vld_orderset}()}
 }
-\concept{chk_set}
+\concept{set_checkers}

--- a/man/chk_superset.Rd
+++ b/man/chk_superset.Rd
@@ -26,6 +26,9 @@ The \code{vld_} function returns a flag indicating whether the test was met.
 Checks if includes all values using
 
 \code{all(values \%in\% x)}
+
+Pay attention to the order of the arguments \code{value} and \code{x}
+in this function compared to \code{\link[=chk_subset]{chk_subset()}}
 }
 \section{Functions}{
 \itemize{
@@ -42,11 +45,16 @@ vld_superset(1:3, 4)
 vld_superset(integer(0), integer(0))
 }
 \seealso{
-Other chk_set: 
-\code{\link{chk_join}()},
+\code{\link[=all]{all()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other set_checkers: 
 \code{\link{chk_not_subset}()},
 \code{\link{chk_orderset}()},
 \code{\link{vld_not_subset}()},
 \code{\link{vld_orderset}()}
 }
-\concept{chk_set}
+\concept{set_checkers}

--- a/man/chk_true.Rd
+++ b/man/chk_true.Rd
@@ -42,9 +42,30 @@ vld_true(0)
 vld_true(c(TRUE, TRUE))
 }
 \seealso{
-Other chk_logical: 
+\code{\link[=is.logical]{is.logical()}}
+
+\code{\link[=length]{length()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other logical_checkers: 
 \code{\link{chk_false}()},
 \code{\link{chk_flag}()},
-\code{\link{chk_lgl}()}
+\code{\link{chk_lgl}()},
+\code{\link{chk_logical}()}
+
+Other scalar_checkers: 
+\code{\link{chk_count}()},
+\code{\link{chk_date}()},
+\code{\link{chk_date_time}()},
+\code{\link{chk_false}()},
+\code{\link{chk_flag}()},
+\code{\link{chk_lgl}()},
+\code{\link{chk_scalar}()},
+\code{\link{chk_string}()},
+\code{\link{chk_tz}()}
 }
-\concept{chk_logical}
+\concept{logical_checkers}
+\concept{scalar_checkers}

--- a/man/chk_tz.Rd
+++ b/man/chk_tz.Rd
@@ -37,12 +37,27 @@ vld_tz("UTC")
 vld_tz("TCU")
 }
 \seealso{
-Other chk_scalars: 
+\code{\link[=length]{length()}}
+
+\code{\link[=OlsonNames]{OlsonNames()}}
+
+\code{\link[=is.character]{is.character()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other scalar_checkers: 
+\code{\link{chk_count}()},
 \code{\link{chk_date}()},
 \code{\link{chk_date_time}()},
-\code{\link{chk_number}()},
+\code{\link{chk_false}()},
+\code{\link{chk_flag}()},
+\code{\link{chk_lgl}()},
 \code{\link{chk_scalar}()},
 \code{\link{chk_string}()},
-\code{\link{chk_whole_number}()}
+\code{\link{chk_true}()}
 }
-\concept{chk_scalars}
+\concept{date_checkers}
+\concept{scalar_checkers}
+\concept{tz_checkers}

--- a/man/chk_unique.Rd
+++ b/man/chk_unique.Rd
@@ -46,15 +46,15 @@ vld_unique(c(NA, NA, 2))
 vld_unique(c(NA, NA, 2), incomparables = NA)
 }
 \seealso{
-Other chk_misc: 
-\code{\link{chk_length}()},
-\code{\link{chk_match}()},
-\code{\link{chk_missing}()},
-\code{\link{chk_named}()},
+\code{\link[=anyDuplicated]{anyDuplicated()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other misc_checkers: 
+\code{\link{chk_join}()},
 \code{\link{chk_not_any_na}()},
-\code{\link{chk_not_empty}()},
-\code{\link{chk_not_missing}()},
-\code{\link{chk_sorted}()},
-\code{\link{chk_valid_name}()}
+\code{\link{chk_not_empty}()}
 }
-\concept{chk_misc}
+\concept{misc_checkers}

--- a/man/chk_unused.Rd
+++ b/man/chk_unused.Rd
@@ -41,7 +41,13 @@ fun(1)
 try(fun(1, 2))
 }
 \seealso{
-Other chk_ellipsis: 
+\code{\link[=length]{length()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other ellipsis_checkers: 
 \code{\link{chk_used}()}
 }
-\concept{chk_ellipsis}
+\concept{ellipsis_checkers}

--- a/man/chk_used.Rd
+++ b/man/chk_used.Rd
@@ -41,7 +41,13 @@ fun(1)
 fun(1, 2)
 }
 \seealso{
-Other chk_ellipsis: 
+\code{\link[=length]{length()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other ellipsis_checkers: 
 \code{\link{chk_unused}()}
 }
-\concept{chk_ellipsis}
+\concept{ellipsis_checkers}

--- a/man/chk_valid_name.Rd
+++ b/man/chk_valid_name.Rd
@@ -38,15 +38,15 @@ try(chk_valid_name(".1"))
 vld_valid_name(".1")
 }
 \seealso{
-Other chk_misc: 
-\code{\link{chk_length}()},
-\code{\link{chk_match}()},
-\code{\link{chk_missing}()},
-\code{\link{chk_named}()},
-\code{\link{chk_not_any_na}()},
-\code{\link{chk_not_empty}()},
-\code{\link{chk_not_missing}()},
-\code{\link{chk_sorted}()},
-\code{\link{chk_unique}()}
+\code{\link[=identical]{identical()}}
+
+\code{\link[=make.names]{make.names()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other name_checkers: 
+\code{\link{chk_named}()}
 }
-\concept{chk_misc}
+\concept{name_checkers}

--- a/man/chk_vector.Rd
+++ b/man/chk_vector.Rd
@@ -43,16 +43,16 @@ try(chk_vector(matrix(1)))
 vld_vector(1)
 }
 \seealso{
-Other chk_is: 
+\code{\link[=is.atomic]{is.atomic()}}, \code{\link[=is.matrix]{is.matrix()}}, \code{\link[=is.array]{is.array()}}, \code{\link[=is.list]{is.list()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other data_structure_checkers: 
 \code{\link{chk_array}()},
 \code{\link{chk_atomic}()},
-\code{\link{chk_data}()},
-\code{\link{chk_function}()},
-\code{\link{chk_is}()},
-\code{\link{chk_matrix}()},
-\code{\link{chk_numeric}()},
-\code{\link{chk_s3_class}()},
-\code{\link{chk_s4_class}()},
-\code{\link{chk_whole_numeric}()}
+\code{\link{chk_list}()},
+\code{\link{chk_matrix}()}
 }
-\concept{chk_is}
+\concept{data_structure_checkers}

--- a/man/chk_whole_number.Rd
+++ b/man/chk_whole_number.Rd
@@ -42,12 +42,19 @@ try(chk_whole_number(1.1))
 vld_whole_number(2)
 }
 \seealso{
-Other chk_scalars: 
-\code{\link{chk_date}()},
-\code{\link{chk_date_time}()},
-\code{\link{chk_number}()},
-\code{\link{chk_scalar}()},
-\code{\link{chk_string}()},
-\code{\link{chk_tz}()}
+\code{\link[=is.integer]{is.integer()}}
+
+\code{\link[=vld_true]{vld_true()}}
+
+\code{\link[=vld_number]{vld_number()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other whole_number_checkers: 
+\code{\link{chk_count}()},
+\code{\link{chk_whole_numeric}()}
 }
-\concept{chk_scalars}
+\concept{scalar_checker}
+\concept{whole_number_checkers}

--- a/man/chk_whole_numeric.Rd
+++ b/man/chk_whole_numeric.Rd
@@ -43,16 +43,20 @@ vld_whole_numeric(TRUE)
 vld_whole_numeric(1.5)
 }
 \seealso{
-Other chk_is: 
-\code{\link{chk_array}()},
-\code{\link{chk_atomic}()},
-\code{\link{chk_data}()},
-\code{\link{chk_function}()},
-\code{\link{chk_is}()},
-\code{\link{chk_matrix}()},
-\code{\link{chk_numeric}()},
-\code{\link{chk_s3_class}()},
-\code{\link{chk_s4_class}()},
-\code{\link{chk_vector}()}
+\code{\link[=is.integer]{is.integer()}}
+
+\code{\link[=is.double]{is.double()}}
+
+\code{\link[=vld_true]{vld_true()}}
+
+\code{\link[=all.equal]{all.equal()}}
+
+For more details about the use of this function,
+please read the article
+\href{https://poissonconsulting.github.io/chk/articles/chk-families.html}{chk families}.
+
+Other whole_number_checkers: 
+\code{\link{chk_count}()},
+\code{\link{chk_whole_number}()}
 }
-\concept{chk_is}
+\concept{whole_number_checkers}

--- a/man/p.Rd
+++ b/man/p.Rd
@@ -16,8 +16,7 @@ p0(..., collapse = NULL)
     \code{\link[base]{NA_character_}}.}
 
 \item{collapse}{an optional character string to separate the results.  Not
-    \code{\link[base]{NA_character_}}.  When \code{collapse} is a string,
-    the result is always a string (\code{\link[base]{character}} of length 1).}
+    \code{\link[base]{NA_character_}}.}
 }
 \value{
 A character vector.


### PR DESCRIPTION
This PR makes some repetitive changes to the documentation of the functions:
1 - Adds a link to `pkgdown`, referring to what was written in the `chk` families article
2 - Updates chk families (`@family` field) based on the new function grouping
3 - Briefly improves the description of `check_data`, `chk_data`, `chk_lgl`, and `chk_logical` to avoid confusion between functions


I created a single commit with all the file modifications, as technically the changes are almost the same across all the files.