### PR TITLE
Fix `chk_is()` error message.

### DIFF
--- a/R/chk-is.R
+++ b/R/chk-is.R
@@ -24,8 +24,8 @@ chk_is <- function(x, class, x_name = NULL) {
     return(invisible(x))
   }
   if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
-  .class <- class
-  abort_chk(x_name, " must inherit from class '", .class, "'", x = x, .class = .class)
+  .class <- cc(class, conj = " or ", chk = FALSE)
+  abort_chk(x_name, " must inherit from class ", .class, x = x, .class = .class)
 }
 
 #' @describeIn chk_is Validate Inherits from Class

--- a/R/chk-s3-class.R
+++ b/R/chk-s3-class.R
@@ -25,8 +25,8 @@ chk_s3_class <- function(x, class, x_name = NULL) {
     return(invisible(x))
   }
   if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
-  .class <- class
-  abort_chk(x_name, " must inherit from S3 class '", .class, "'", x = x, .class = .class)
+  .class <- cc(class, conj = " or ", chk = FALSE)
+  abort_chk(x_name, " must inherit from S3 class ", .class, x = x, .class = .class)
 }
 
 #' @describeIn chk_s3_class Validate Inherits from S3 Class

--- a/R/chk-s4-class.R
+++ b/R/chk-s4-class.R
@@ -25,8 +25,8 @@ chk_s4_class <- function(x, class, x_name = NULL) {
     return(invisible(x))
   }
   if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
-  .class <- class
-  abort_chk(x_name, " must inherit from S4 class '", .class, "'", x = x, .class = .class)
+  .class <- cc(class, conj = " or ", chk = FALSE)
+  abort_chk(x_name, " must inherit from S4 class ", .class, x = x, .class = .class)
 }
 
 #' @describeIn chk_s4_class Validate Inherits from S4 Class

--- a/R/params.R
+++ b/R/params.R
@@ -22,7 +22,7 @@
 #' @param inclusive A flag specifying whether the range is exclusive.
 #' @param regexp A string of a regular expression.
 #' @param values A vector of the permitted values.
-#' @param class A string specifying the class.
+#' @param class A character vector specifying the possible class values.
 #' @param length A count of the length.
 #' @param upper A count of the max length.
 #' @param formals A count of the number of formal arguments.

--- a/man/chk_is.Rd
+++ b/man/chk_is.Rd
@@ -12,7 +12,7 @@ vld_is(x, class)
 \arguments{
 \item{x}{The object to check.}
 
-\item{class}{A string specifying the class.}
+\item{class}{A character vector specifying the possible class values.}
 
 \item{x_name}{A string of the name of object x or NULL.}
 }

--- a/man/chk_s3_class.Rd
+++ b/man/chk_s3_class.Rd
@@ -12,7 +12,7 @@ vld_s3_class(x, class)
 \arguments{
 \item{x}{The object to check.}
 
-\item{class}{A string specifying the class.}
+\item{class}{A character vector specifying the possible class values.}
 
 \item{x_name}{A string of the name of object x or NULL.}
 }

--- a/man/chk_s4_class.Rd
+++ b/man/chk_s4_class.Rd
@@ -12,7 +12,7 @@ vld_s4_class(x, class)
 \arguments{
 \item{x}{The object to check.}
 
-\item{class}{A string specifying the class.}
+\item{class}{A character vector specifying the possible class values.}
 
 \item{x_name}{A string of the name of object x or NULL.}
 }

--- a/man/params.Rd
+++ b/man/params.Rd
@@ -37,7 +37,7 @@ upper permitted values.}
 
 \item{values}{A vector of the permitted values.}
 
-\item{class}{A string specifying the class.}
+\item{class}{A character vector specifying the possible class values.}
 
 \item{length}{A count of the length.}
 

--- a/tests/testthat/test-chk-is.R
+++ b/tests/testthat/test-chk-is.R
@@ -21,4 +21,8 @@ test_that("chk_is", {
   class(x) <- c("a", "b")
   expect_chk_error(chk_is(x, "c"), "`x` must inherit from class 'c'")
   expect_chk_error(chk_is(x, "c", x_name = "c"), "C must inherit from class 'c'")
+
+  foo <- 1
+  class(foo) <- "a"
+  expect_chk_error(chk_is(foo, c("b", "c")), "`foo` must inherit from class 'b' or 'c'.")
 })

--- a/tests/testthat/test-chk-type.R
+++ b/tests/testthat/test-chk-type.R
@@ -22,6 +22,10 @@ test_that("chk_s3_class", {
   class(x) <- c("a", "b")
   expect_chk_error(chk_s3_class(x, "c"), "`x` must inherit from S3 class 'c'")
   expect_chk_error(chk_s3_class(x, "c", x_name = "c"), "C must inherit from S3 class 'c'")
+
+  foo <- 1
+  class(foo) <- "a"
+  expect_chk_error(chk_s3_class(foo, c("b", "c")), "`foo` must inherit from S3 class 'b' or 'c'.")
 })
 
 
@@ -41,6 +45,10 @@ test_that("chk_s4_class", {
     chk_s4_class(matrix(1), "numeric"),
     "`matrix[(]1[)]` must inherit from S4 class 'numeric'[.]$"
   )
+
+  foo <- 1
+  class(foo) <- "a"
+  expect_chk_error(chk_s4_class(foo, c("b", "c")), "`foo` must inherit from S4 class 'b' or 'c'.")
 })
 
 test_that("vld_whole_numeric", {


### PR DESCRIPTION
- Fix error message when `chk_is()`, `chk_s3_class()` and `chk_s4_class()` fail with multiple possible class values.

closes  #185 
