### PR TITLE
Fix inclusive argument docs for chk_range()

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -19,7 +19,7 @@
 #' @param value A non-missing scalar of a value.
 #' @param range A non-missing sorted vector of length 2 of the lower and
 #'   upper permitted values.
-#' @param inclusive A flag specifying whether the range is exclusive.
+#' @param inclusive A flag specifying whether the range is inclusive.
 #' @param regexp A string of a regular expression.
 #' @param values A vector of the permitted values.
 #' @param class A character vector specifying the possible class values.

--- a/man/chk_range.Rd
+++ b/man/chk_range.Rd
@@ -15,7 +15,7 @@ vld_range(x, range = c(0, 1), inclusive = TRUE)
 \item{range}{A non-missing sorted vector of length 2 of the lower and
 upper permitted values.}
 
-\item{inclusive}{A flag specifying whether the range is exclusive.}
+\item{inclusive}{A flag specifying whether the range is inclusive.}
 
 \item{x_name}{A string of the name of object x or NULL.}
 }

--- a/man/params.Rd
+++ b/man/params.Rd
@@ -31,7 +31,7 @@
 \item{range}{A non-missing sorted vector of length 2 of the lower and
 upper permitted values.}
 
-\item{inclusive}{A flag specifying whether the range is exclusive.}
+\item{inclusive}{A flag specifying whether the range is inclusive.}
 
 \item{regexp}{A string of a regular expression.}
 


### PR DESCRIPTION
The `inclusive` argument description for `chk_range()` / `vld_range()` incorrectly stated the range is *exclusive* when it should say *inclusive*.

Fixed the roxygen source in `R/params.R` and regenerated the affected `.Rd` files (`man/chk_range.Rd`, `man/params.Rd`).

Closes #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)