### PR TITLE
Fix malformed author name in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0003-4470-8361")),
     person("Evan", "Amies-Galonski", , "evan@poissonconsulting.ca", role = "ctb",
            comment = c(ORCID = "0000-0003-1096-2089")),
-    person("Stefano", "Mezzini", "stefano@poissonconsulting.ca", role = "ctb",
+    person("Stefano", "Mezzini", , "stefano@poissonconsulting.ca", role = "ctb",
            comment = c(ORCID = "0000-0001-8551-7436")),
     person("Poisson Consulting", role = c("cph", "fnd"))
   )

--- a/man/chk-package.Rd
+++ b/man/chk-package.Rd
@@ -34,7 +34,7 @@ Other contributors:
   \item Florencia D'Andrea [contributor]
   \item Nadine Hussein \email{nadine@poissonconsulting.ca} (\href{https://orcid.org/0000-0003-4470-8361}{ORCID}) [contributor]
   \item Evan Amies-Galonski \email{evan@poissonconsulting.ca} (\href{https://orcid.org/0000-0003-1096-2089}{ORCID}) [contributor]
-  \item Stefano stefano@poissonconsulting.ca Mezzini (\href{https://orcid.org/0000-0001-8551-7436}{ORCID}) [contributor]
+  \item Stefano Mezzini \email{stefano@poissonconsulting.ca} (\href{https://orcid.org/0000-0001-8551-7436}{ORCID}) [contributor]
   \item Poisson Consulting [copyright holder, funder]
 }
 


### PR DESCRIPTION
## Summary

Fixes a malformed author name in `DESCRIPTION`.

## Problem

Stefano Mezzini's `person()` call omitted the empty `middle` positional argument:

```
person("Stefano", "Mezzini", "stefano@poissonconsulting.ca", role = "ctb", ...)
```

`person()`'s third positional argument is `middle`, so the email was parsed as the middle name. The author rendered as **`Stefano stefano@poissonconsulting.ca Mezzini`** (visible in `format(as.person(...))` and anywhere the author list is displayed).

## Change

- `DESCRIPTION` — added the empty positional so the email lands in the `email` field, matching the other entries (e.g. Nadine Hussein, Evan Amies-Galonski):

```
person("Stefano", "Mezzini", , "stefano@poissonconsulting.ca", role = "ctb", ...)
```

No other files changed.

## Verification

After the fix, `utils::as.person()` parses the entry as name `Stefano Mezzini` with email `stefano@poissonconsulting.ca`.
