### PR TITLE
Enforce S4 class cleanup in test via withr local function

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,5 @@
+local_s4_class <- function(Class, ..., .local_envir = parent.frame()) {
+  methods::setClass(Class, ...)
+  withr::defer(methods::removeClass(Class), envir = .local_envir)
+  invisible(Class)
+}

--- a/tests/testthat/test-chk-s3-class.R
+++ b/tests/testthat/test-chk-s3-class.R
@@ -3,10 +3,9 @@ test_that("vld_s3_class", {
   expect_false(vld_s3_class(1L, "numeric"))
   expect_true(vld_s3_class(1L, "integer"))
 
-  setClass("exampleS4class", slots = c(value = "numeric"))
+  local_s4_class("exampleS4class", slots = c(value = "numeric"))
   expect_true(class(new("exampleS4class")) == "exampleS4class")
   expect_false(vld_s3_class(new("exampleS4class"), "exampleS4class"))
-  invisible(removeClass("exampleS4class"))
 
   expect_true(
     class(setRefClass("exampleRefClass", fields = "value")$new()) ==


### PR DESCRIPTION
Targets the `fix-s3-check` branch (PR to a PR).

## Summary

Replaces the manual `setClass()` / `removeClass()` pair in `test-chk-s3-class.R` with a `local_s4_class()` helper that defers cleanup via `withr::defer()`, so the temporary S4 class is removed regardless of whether an intervening expectation errors.

## Changes

- Add `tests/testthat/helper.R` defining `local_s4_class()`, which calls `methods::setClass()` and registers `methods::removeClass()` with `withr::defer()` scoped to the calling test environment.
- Update `test-chk-s3-class.R` to use `local_s4_class()` and drop the explicit `removeClass()` call.

`withr` is already in `Suggests`.

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)