### PR TITLE
Update Evan Amies-Galonski email to personal address

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
     person("Florencia", "D'Andrea", role = "ctb"),
     person("Nadine", "Hussein", , "nadine@poissonconsulting.ca", role = "ctb",
            comment = c(ORCID = "0000-0003-4470-8361")),
-    person("Evan", "Amies-Galonski", , "evan@poissonconsulting.ca", role = "ctb",
+    person("Evan", "Amies-Galonski", , "evanamiesgalonski@gmail.com", role = "ctb",
            comment = c(ORCID = "0000-0003-1096-2089")),
     person("Stefano", "Mezzini", , "stefano@poissonconsulting.ca", role = "ctb",
            comment = c(ORCID = "0000-0001-8551-7436")),

--- a/man/chk-package.Rd
+++ b/man/chk-package.Rd
@@ -33,7 +33,7 @@ Other contributors:
 \itemize{
   \item Florencia D'Andrea [contributor]
   \item Nadine Hussein \email{nadine@poissonconsulting.ca} (\href{https://orcid.org/0000-0003-4470-8361}{ORCID}) [contributor]
-  \item Evan Amies-Galonski \email{evan@poissonconsulting.ca} (\href{https://orcid.org/0000-0003-1096-2089}{ORCID}) [contributor]
+  \item Evan Amies-Galonski \email{evanamiesgalonski@gmail.com} (\href{https://orcid.org/0000-0003-1096-2089}{ORCID}) [contributor]
   \item Stefano Mezzini \email{stefano@poissonconsulting.ca} (\href{https://orcid.org/0000-0001-8551-7436}{ORCID}) [contributor]
   \item Poisson Consulting [copyright holder, funder]
 }


### PR DESCRIPTION
Replaces `evan@poissonconsulting.ca` (no longer an active address) with Evan's personal email `evanamiesgalonski@gmail.com` in DESCRIPTION.