### PR TITLE
Add tests for defunct chk_off(), chk_on() and is_chk_on()

### DIFF
--- a/tests/testthat/test-aaa-deprecated.R
+++ b/tests/testthat/test-aaa-deprecated.R
@@ -1,3 +1,9 @@
+test_that("chk_off, chk_on and is_chk_on are defunct", {
+  expect_error(chk_off(), class = "defunctError")
+  expect_error(chk_on(), class = "defunctError")
+  expect_error(is_chk_on(), class = "defunctError")
+})
+
 test_that("vld_no_missing", {
   rlang::local_options(lifecycle_verbosity = "quiet")
 


### PR DESCRIPTION
## Summary

`chk_off()`, `chk_on()` and `is_chk_on()` are exported, call `deprecate_stop()`, and had no test coverage. This adds assertions that each raises a `defunctError`.

## Test plan

`devtools::test()` passes (1150 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)