### PR TITLE
Improve documentation accuracy and completeness

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -141,7 +141,6 @@ reference:
   contents:
   - chk_not_any_na
   - chk_not_empty
-  - chk_sorted
   - chk_unique
   - chk_join
   - chkor_vld
@@ -185,3 +184,4 @@ reference:
   - chk_lgl
   - chk_wnum
   - chkor
+  - chk_deprecated

--- a/vignettes/chk-families.Rmd
+++ b/vignettes/chk-families.Rmd
@@ -19,7 +19,7 @@ library(chk)
 The `vld_` functions are used within the `chk_` functions.
 The `chk_` functions (and their `vld_` equivalents) can be divided into the following families.
 
-In the code in this examples, we will use `vld_*` functions
+In the code in these examples, we will use `vld_*` functions.
 
 If you want to learn more about the logic behind some of the functions explained here, we recommend reading the book [Advanced R](https://adv-r.hadley.nz/) (Wickham, 2019).
 
@@ -133,7 +133,7 @@ To check if a function argument is a vector you can use `chk_vector()`.
  
 Function | Code
 :- | :---
-`chk_vector(x)` | `is.atomic(x) && !is.matrix(x) && !is.array(x)) || is.list(x)`
+`chk_vector(x)` | `(is.atomic(x) && !is.matrix(x) && !is.array(x)) || is.list(x)`
 
 Pay attention that `chk_vector()` and `vld_vector()` 
 are different from `is.vector()`, that will return FALSE if the vector has any attributes except names.
@@ -151,15 +151,16 @@ Function | Code
 :- | :---
 `chk_atomic(x)` | `is.atomic(x)`
 
-Notice that `is.atomic` is true for the types logical, integer, numeric, complex, character and raw. Also, it is TRUE for NULL.
+Notice that `is.atomic()` is `TRUE` for the types logical, integer, numeric, complex, character and raw.
+As of R 4.4.0 it is `FALSE` for `NULL` (it was `TRUE` in earlier versions).
 
 ```{r}
 vector <- c(1, 2, 3)
 is.atomic(vector) # TRUE
-vld_vector(vector) # TRUE
+vld_atomic(vector) # TRUE
 
-is.atomic(NULL) # TRUE
-vld_vector(NULL) # TRUE
+is.atomic(NULL) # FALSE (as of R 4.4.0)
+vld_atomic(NULL) # FALSE (as of R 4.4.0)
 ```
 
 The dimension attribute converts vectors into matrices and arrays.
@@ -169,12 +170,12 @@ Function | Code
 `chk_array(x)` | `is.array(x)`
 `chk_matrix(x)` | `is.matrix(x)`
 
-When a vector is composed by heterogeneous data types, can be a list.
+When a vector is composed of heterogeneous data types, it can be a list.
 Data frames are among the most important S3 vectors, constructed on top of lists.
 
 Function | Code
 :- | :---
-`chk_list(x)` | `is.list()`
+`chk_list(x)` | `is.list(x)`
 `chk_data(x)` | `inherits(x, "data.frame")`
 
 Be careful not to confuse the function `chk_data` with `check_data`.
@@ -268,7 +269,7 @@ Function | Code
 `chk_factor` | `is.factor(x)`
 `chk_character_or_factor` | `is.character(x) || is.factor(x)`
 
-Factors can be specially confusing for users, because despite they are displayed as characters are built in top of integer vectors.
+Factors can be especially confusing for users because, despite being displayed as characters, they are built on top of integer vectors.
 
 `chk` provides the function `chk_character_or_factor()` that allows detecting if the argument that the user is providing contains strings. 
 
@@ -569,7 +570,7 @@ vld_length(NULL, length = 1) # FALSE
 ```
 
 
-Another useful function is `chk_compatible_lenghts()`.
+Another useful function is `chk_compatible_lengths()`.
 This function helps to check vectors could be 'strictly recycled'.
 
 ```{r}

--- a/vignettes/chk.Rmd
+++ b/vignettes/chk.Rmd
@@ -49,7 +49,7 @@ For example,
 
 `chk_` functions are called for their side-effects, 
 i.e., they throw an informative error if the object fails the check.
-Although do return an invisible copy of the first argument so they can be used in pipes.
+They do, however, return an invisible copy of the first argument so they can be used in pipes.
 
 ```{r, error=TRUE}
 library(chk)
@@ -60,7 +60,7 @@ chk_flag(y)
 ```
 
 The error messages, which follow the [tidyverse style guide](https://style.tidyverse.org/errors.html), are designed to allow the user to quickly identify the problem with the argument value(s) they are providing.
-The errors are [rlang  errors](https://rlang.r-lib.org/reference/abort.html) of subclass `'chk_error'`.
+The errors are [rlang errors](https://rlang.r-lib.org/reference/abort.html) of subclass `'chk_error'`.
 
 ### 2. `vld_` Functions
 
@@ -77,7 +77,7 @@ if (!vld_flag(NA)) abort_chk("`NA` is not TRUE or FALSE!!")
 
 ### 3. `check_` Functions
 
-The `check_` functions are more complex then the `chk_` functions which make them slower but 
+The `check_` functions are more complex than the `chk_` functions, which makes them slower but
 makes doing some general tests easier.
 
 ## Using chk
@@ -116,7 +116,7 @@ chk_flag
 #> function(x, x_name = NULL){
 #>   if(vld_flag(x)) return(invisible(x))
 #>   if(is.null(x_name))  x_name <- deparse_backtick_chk(substitute(x))
-#>   abort_chk(x_name, " must be a flag (TRUE or FALSE)")
+#>   abort_chk(x_name, " must be a flag (TRUE or FALSE)", x = x)
 #> }
 #> <bytecode: 0x7fe802835670>
 #> <environment: namespace:chk>
@@ -126,7 +126,7 @@ A `chk_` function initially checks the object (using its `vld_` partner) and if 
 If, and only if, the object fails the check does the `chk_` function construct and then throw an informative error message.
 
 The `deparse_backtick_chk()` and `abort_chk()` functions are exported to make it easy for programmers to develop their own `chk_` functions.
-The [chk-lgl.R](https://github.com/poissonconsulting/chk/blob/master/R/chk-lgl.R) script illustrates
+The [chk-flag.R](https://github.com/poissonconsulting/chk/blob/main/R/chk-flag.R) script illustrates
 the general template to use when developing your own `chk_` functions.
 
 ### `abort_chk()`


### PR DESCRIPTION
## Summary

Documentation-only fixes across the vignettes and the pkgdown reference index. Both vignettes knit cleanly.

### Factual correction
- `chk-families.Rmd` stated `is.atomic(NULL)` and `vld_atomic(NULL)` are `TRUE`. Both return `FALSE` as of **R 4.4.0** (the package depends on R >= 4.1), so the rendered live chunk contradicted the prose. Corrected the annotations and prose, and switched that section from `vld_vector()` to `vld_atomic()` (it demonstrates `chk_atomic`).

### Broken / stale references
- `chk.Rmd` linked to `blob/master/R/chk-lgl.R` — there is no `master` branch (default is `main`), and `chk_lgl` is deprecated. Repointed to `blob/main/R/chk-flag.R`, matching the example shown.
- Updated the displayed `chk_flag` body, which was missing `, x = x`.

### Code-table typos (`chk-families.Rmd`)
- `chk_vector` had an unbalanced parenthesis.
- `chk_list` showed `is.list()` with no argument.

### Reference index (`_pkgdown.yml`)
- `chk_sorted` was listed twice (Order and Quality sections); kept under Order only.
- Ten exported deprecated functions (`chk_dirs`, `chk_files`, `chk_has`, `chk_in`, `chk_no_missing`, `chk_off`, `chk_on`, `is_chk_on`, `chk_proportion`, `deparse_backtick`) were absent from the index. Added the shared `chk_deprecated` topic that documents them. Verified with pkgdown's alias->topic logic that every export is now covered and nothing renders twice.

### Grammar / typos
"complex then"->"than", "Although do return", "in this examples", "specially confusing", "chk_compatible_lenghts", and a double space in "rlang  errors".

## Test plan
- `rmarkdown::render()` succeeds for both `chk.Rmd` and `chk-families.Rmd`.
- Reference-index coverage checked programmatically against NAMESPACE exports and man/ aliases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)