### PR TITLE
Add x_name argument to chkor_vld() (#100)

### DIFF
--- a/R/chkor-vld.R
+++ b/R/chkor-vld.R
@@ -47,6 +47,10 @@ vld__to_chk_ <- function(quo) {
 #' If at all possible use [chk_null_or()] or first test using the individual
 #' `vld_` functions and then call `chkor_vld()` to generate an informative
 #' error message.
+#' @param x_name A string of the name of the object to use in the error
+#' message or NULL. If a string it is passed to each of the `chk_` calls so
+#' that the error message refers to `x_name` rather than the deparsed `vld_`
+#' arguments.
 #'
 #' @return An informative error if the test fails.
 #'
@@ -60,7 +64,8 @@ vld__to_chk_ <- function(quo) {
 #' try(chkor_vld(vld_flag(1)))
 #' try(chkor_vld(vld_flag(1), vld_flag(2)))
 #' chkor_vld(vld_flag(1), vld_flag(TRUE))
-chkor_vld <- function(...) {
+#' try(chkor_vld(vld_flag(1), vld_number(1), x_name = "`arg`"))
+chkor_vld <- function(..., x_name = NULL) {
   quos <- enquos(...)
 
   n <- length(quos)
@@ -73,7 +78,11 @@ chkor_vld <- function(...) {
     }
   }
   for (i in seq_len(n)) {
-    quos[[i]] <- quo_set_expr(quos[[i]], vld__to_chk_(quo_get_expr(quos[[i]])))
+    expr <- vld__to_chk_(quo_get_expr(quos[[i]]))
+    if (!is.null(x_name)) {
+      expr <- call_modify(expr, x_name = x_name)
+    }
+    quos[[i]] <- quo_set_expr(quos[[i]], expr)
   }
   chkor_quos(quos)
 }

--- a/man/chkor_vld.Rd
+++ b/man/chkor_vld.Rd
@@ -4,7 +4,7 @@
 \alias{chkor_vld}
 \title{Chk OR}
 \usage{
-chkor_vld(...)
+chkor_vld(..., x_name = NULL)
 }
 \arguments{
 \item{...}{Multiple \code{vld_} calls.
@@ -15,6 +15,11 @@ A common mistake is to pass \code{chk_} calls.
 If at all possible use \code{\link[=chk_null_or]{chk_null_or()}} or first test using the individual
 \code{vld_} functions and then call \code{chkor_vld()} to generate an informative
 error message.}
+
+\item{x_name}{A string of the name of the object to use in the error
+message or NULL. If a string it is passed to each of the \code{chk_} calls so
+that the error message refers to \code{x_name} rather than the deparsed \code{vld_}
+arguments.}
 }
 \value{
 An informative error if the test fails.
@@ -28,6 +33,7 @@ chkor_vld(vld_flag(TRUE))
 try(chkor_vld(vld_flag(1)))
 try(chkor_vld(vld_flag(1), vld_flag(2)))
 chkor_vld(vld_flag(1), vld_flag(TRUE))
+try(chkor_vld(vld_flag(1), vld_number(1), x_name = "`arg`"))
 }
 \seealso{
 \code{\link[=chk_null_or]{chk_null_or()}}

--- a/tests/testthat/test-chkor-vld.R
+++ b/tests/testthat/test-chkor-vld.R
@@ -21,3 +21,32 @@ test_that("chkor_vld", {
     "^At least one of the following conditions must be met:\n[*] `1` must be a flag [(]TRUE or FALSE[)].\n[*] `2` must be a flag [(]TRUE or FALSE[)].\n[*] `0` must be a flag [(]TRUE or FALSE[)].$"
   )
 })
+
+test_that("chkor_vld x_name is passed to all chk calls", {
+  expect_null(chkor_vld(vld_flag(TRUE), x_name = "`arg`"))
+  expect_invisible(chkor_vld(vld_flag(TRUE), x_name = "`arg`"))
+
+  # single failing condition uses x_name instead of the deparsed argument
+  expect_chk_error(
+    chkor_vld(vld_flag(1), x_name = "`arg`"),
+    "^`arg` must be a flag [(]TRUE or FALSE[)][.]$"
+  )
+
+  # x_name is applied to every condition
+  expect_chk_error(
+    chkor_vld(vld_flag("a"), vld_number("a"), x_name = "`arg`"),
+    "^At least one of the following conditions must be met:\n[*] `arg` must be a flag [(]TRUE or FALSE[)].\n[*] `arg` must be a number [(]non-missing numeric scalar[)].$"
+  )
+
+  # x_name coexists with other arguments passed to the vld_ call
+  expect_chk_error(
+    chkor_vld(vld_gte(1, value = 5), x_name = "`arg`"),
+    "^`arg` must be greater than or equal to 5, not 1[.]$"
+  )
+
+  # default (NULL) still deparses the argument
+  expect_chk_error(
+    chkor_vld(vld_flag(1)),
+    "^`1` must be a flag [(]TRUE or FALSE[)][.]$"
+  )
+})


### PR DESCRIPTION
## Summary

Implements #100: `chkor_vld()` gains an `x_name = NULL` argument that is passed to all of the underlying `chk_` calls.

When every `vld_` condition fails, `chkor_vld()` rebuilds the error message by converting each `vld_xxx(...)` call to its `chk_xxx(...)` partner and collecting the messages. Previously each message referred to the deparsed `vld_` argument (e.g. `` `1` ``). With `x_name` supplied, that name is used instead:

```r
chkor_vld(vld_flag(1), vld_number(1), x_name = "`arg`")
#> Error: At least one of the following conditions must be met:
#> * `arg` must be a flag (TRUE or FALSE).
#> * `arg` must be a number (non-missing numeric scalar).
```

## Implementation

- Signature is now `chkor_vld(..., x_name = NULL)` (`x_name` is after `...`, so it must be passed by name and never collides with the captured conditions).
- The name is injected into each converted `chk_` call with `rlang::call_modify()`, so it composes with any other arguments in the `vld_` call (e.g. `vld_gte(x, value = 5)` still reports the bound).
- Default behaviour (`x_name = NULL`) is unchanged.

## Test plan

- Added tests covering: single condition, multiple conditions, composition with extra `vld_` arguments, the passing case, and the unchanged `NULL` default.
- `devtools::test()` passes (1165 tests); examples run; docs regenerated.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)