### PR TITLE
Fix factor edge cases in check_values() (#298 review)

### DIFF
--- a/R/check-data.R
+++ b/R/check-data.R
@@ -3,6 +3,11 @@
 #' @description
 #' Checks column names, values, number of rows and key for a data.frame.
 #'
+#' @details
+#' The values of each column are checked using [check_values()].
+#' See its details for the rules including those for factor levels
+#' and missing values.
+#'
 #' @inheritParams params
 #' @param values A uniquely named list of atomic vectors of the column values.
 #' @return An informative error if the test fails or an invisible copy of x.

--- a/R/check-values.R
+++ b/R/check-values.R
@@ -20,7 +20,7 @@
 #' To check that x only includes specific values
 #' pass three or more non-missing values.
 #'
-#' In the case of a factor if values has two or more levels
+#' In the case of a factor if `values` has two or more levels
 #' then the levels of `x` must be identical,
 #' including their order, to the levels of `values`.
 #' A factor with less than two levels only checks that `x` is a factor.

--- a/R/check-values.R
+++ b/R/check-values.R
@@ -22,7 +22,7 @@
 #'
 #' In the case of a factor if values has two or more levels
 #' then the levels of x must be identical,
-#' including their order, to the levels of values.
+#' including their order, to the levels of `values`.
 #' A factor with less than two levels only checks that x is a factor.
 #' Thus `factor(1)` allows any factor without missing values,
 #' `factor(c(1, NA))` any factor with or without missing values and

--- a/R/check-values.R
+++ b/R/check-values.R
@@ -23,7 +23,7 @@
 #' In the case of a factor if values has two or more levels
 #' then the levels of x must be identical,
 #' including their order, to the levels of `values`.
-#' A factor with less than two levels only checks that x is a factor.
+#' A factor with less than two levels only checks that `x` is a factor.
 #' Thus `factor(1)` allows any factor without missing values,
 #' `factor(c(1, NA))` any factor with or without missing values and
 #' `factor(NA)` any factor with all missing values.

--- a/R/check-values.R
+++ b/R/check-values.R
@@ -20,9 +20,12 @@
 #' To check that x only includes specific values
 #' pass three or more non-missing values.
 #'
-#' In the case of a factor ensure values has two levels to
-#' check that the levels of x are an ordered superset of the levels of value
-#' and three or more levels to check that they are identical.
+#' In the case of a factor if values has two or more levels,
+#' or one level together with a missing value,
+#' then the levels of x must be identical,
+#' including their order, to the levels of values.
+#' A factor with one level and no missing values
+#' only checks that x is a factor.
 #'
 #' @inheritParams params
 #' @param values An atomic vector specifying the S3 class and possible values.
@@ -47,22 +50,12 @@ check_values <- function(x, values, x_name = NULL) {
 
   class <- class(values)[1]
   chk_class(x, class, x_name = x_name)
-  if (is.factor(values)) {
-    chk_subset(unique(values), c(levels(values), NA))
-
+  if (is.factor(values) && (nlevels(values) > 1 || length(unique(values)) > 1)) {
     x_name_levels <- backtick_chk(p0("levels(", unbacktick_chk(x_name), ")"))
-    if (nlevels(values) == 0) {
-      chk_all_na(x, x_name = x_name)
-    }
-    if (nlevels(values) == 1) {
-      chk_gt(nlevels(x))
-    }
-    if (nlevels(values) > 1 || length(unique(values)) > 1) {
-      # using super/subset for more informative errors than chk_identical()
-      chk_superset(levels(x), levels(values), x_name = x_name_levels)
-      chk_subset(levels(x), levels(values), x_name = x_name_levels)
-      chk_orderset(levels(x), levels(values), x_name = x_name_levels)
-    }
+    # using super/subset for more informative errors than chk_identical()
+    chk_superset(levels(x), levels(values), x_name = x_name_levels)
+    chk_subset(levels(x), levels(values), x_name = x_name_levels)
+    chk_orderset(levels(x), levels(values), x_name = x_name_levels)
   }
   if (!length(x) || !length(values)) {
     return(invisible(x))

--- a/R/check-values.R
+++ b/R/check-values.R
@@ -20,12 +20,13 @@
 #' To check that x only includes specific values
 #' pass three or more non-missing values.
 #'
-#' In the case of a factor if values has two or more levels,
-#' or one level together with a missing value,
+#' In the case of a factor if values has two or more levels
 #' then the levels of x must be identical,
 #' including their order, to the levels of values.
-#' A factor with one level and no missing values
-#' only checks that x is a factor.
+#' A factor with less than two levels only checks that x is a factor.
+#' Thus `factor(1)` allows any factor without missing values,
+#' `factor(c(1, NA))` any factor with or without missing values and
+#' `factor(NA)` any factor with all missing values.
 #'
 #' @inheritParams params
 #' @param values An atomic vector specifying the S3 class and possible values.
@@ -50,7 +51,7 @@ check_values <- function(x, values, x_name = NULL) {
 
   class <- class(values)[1]
   chk_class(x, class, x_name = x_name)
-  if (is.factor(values) && (nlevels(values) > 1 || length(unique(values)) > 1)) {
+  if (is.factor(values) && nlevels(values) > 1) {
     x_name_levels <- backtick_chk(p0("levels(", unbacktick_chk(x_name), ")"))
     # using super/subset for more informative errors than chk_identical()
     chk_superset(levels(x), levels(values), x_name = x_name_levels)

--- a/R/check-values.R
+++ b/R/check-values.R
@@ -21,7 +21,7 @@
 #' pass three or more non-missing values.
 #'
 #' In the case of a factor if values has two or more levels
-#' then the levels of x must be identical,
+#' then the levels of `x` must be identical,
 #' including their order, to the levels of `values`.
 #' A factor with less than two levels only checks that `x` is a factor.
 #' Thus `factor(1)` allows any factor without missing values,

--- a/R/chk-orderset.R
+++ b/R/chk-orderset.R
@@ -36,7 +36,7 @@ chk_orderset <- function(x, values, x_name = NULL) {
   values <- values[values %in% x]
   abort_chk(
     x_name,
-    " must have (the first occurence of) each of the following elements in the following order: ",
+    " must have each of the following elements in the following order: ",
     cc(values),
     x = x,
     values = values

--- a/man/check_data.Rd
+++ b/man/check_data.Rd
@@ -35,6 +35,11 @@ An informative error if the test fails or an invisible copy of x.
 \description{
 Checks column names, values, number of rows and key for a data.frame.
 }
+\details{
+The values of each column are checked using \code{\link[=check_values]{check_values()}}.
+See its details for the rules including those for factor levels
+and missing values.
+}
 \examples{
 check_data(data.frame())
 check_data(data.frame(x = 2), list(x = 1))

--- a/man/check_values.Rd
+++ b/man/check_values.Rd
@@ -36,12 +36,13 @@ To check the range of the values in x pass two non-missing values
 To check that x only includes specific values
 pass three or more non-missing values.
 
-In the case of a factor if values has two or more levels,
-or one level together with a missing value,
+In the case of a factor if values has two or more levels
 then the levels of x must be identical,
 including their order, to the levels of values.
-A factor with one level and no missing values
-only checks that x is a factor.
+A factor with less than two levels only checks that x is a factor.
+Thus \code{factor(1)} allows any factor without missing values,
+\code{factor(c(1, NA))} any factor with or without missing values and
+\code{factor(NA)} any factor with all missing values.
 }
 \examples{
 check_values(1, numeric(0))

--- a/man/check_values.Rd
+++ b/man/check_values.Rd
@@ -36,9 +36,12 @@ To check the range of the values in x pass two non-missing values
 To check that x only includes specific values
 pass three or more non-missing values.
 
-In the case of a factor ensure values has two levels to
-check that the levels of x are an ordered superset of the levels of value
-and three or more levels to check that they are identical.
+In the case of a factor if values has two or more levels,
+or one level together with a missing value,
+then the levels of x must be identical,
+including their order, to the levels of values.
+A factor with one level and no missing values
+only checks that x is a factor.
 }
 \examples{
 check_values(1, numeric(0))

--- a/man/check_values.Rd
+++ b/man/check_values.Rd
@@ -36,7 +36,7 @@ To check the range of the values in x pass two non-missing values
 To check that x only includes specific values
 pass three or more non-missing values.
 
-In the case of a factor if values has two or more levels
+In the case of a factor if \code{values} has two or more levels
 then the levels of x must be identical,
 including their order, to the levels of values.
 A factor with less than two levels only checks that x is a factor.

--- a/man/check_values.Rd
+++ b/man/check_values.Rd
@@ -39,7 +39,7 @@ pass three or more non-missing values.
 In the case of a factor if \code{values} has two or more levels
 then the levels of x must be identical,
 including their order, to the levels of values.
-A factor with less than two levels only checks that x is a factor.
+A factor with less than two levels only checks that \code{x} is a factor.
 Thus \code{factor(1)} allows any factor without missing values,
 \code{factor(c(1, NA))} any factor with or without missing values and
 \code{factor(NA)} any factor with all missing values.

--- a/man/check_values.Rd
+++ b/man/check_values.Rd
@@ -37,7 +37,7 @@ To check that x only includes specific values
 pass three or more non-missing values.
 
 In the case of a factor if \code{values} has two or more levels
-then the levels of x must be identical,
+then the levels of \code{x} must be identical,
 including their order, to the levels of \code{values}.
 A factor with less than two levels only checks that \code{x} is a factor.
 Thus \code{factor(1)} allows any factor without missing values,

--- a/man/check_values.Rd
+++ b/man/check_values.Rd
@@ -38,7 +38,7 @@ pass three or more non-missing values.
 
 In the case of a factor if \code{values} has two or more levels
 then the levels of x must be identical,
-including their order, to the levels of values.
+including their order, to the levels of \code{values}.
 A factor with less than two levels only checks that \code{x} is a factor.
 Thus \code{factor(1)} allows any factor without missing values,
 \code{factor(c(1, NA))} any factor with or without missing values and

--- a/tests/testthat/test-check-data.R
+++ b/tests/testthat/test-check-data.R
@@ -96,10 +96,9 @@ test_that("factors are handled correctly.", {
                           list(fac = factor(NA, levels = "b"))),
                "`data.frame(fac = factor(c(\"a\", \"b\", \"c\", \"z\")))$fac` must only have missing values.",
                fixed = TRUE)
-  expect_error(check_data(data.frame(fac = factor(c("a", "b", "c", "z"))),
-                          list(fac = factor(c("b", NA), levels = "b"))),
-               "`levels(data.frame(fac = factor(c(\"a\", \"b\", \"c\", \"z\")))$fac)` must have values matching 'b'.",
-               fixed = TRUE)
+  # one level plus NA means any factor with missing values allowed
+  expect_no_error(check_data(data.frame(fac = factor(c("a", "b", "c", "z"))),
+                             list(fac = factor(c("b", NA), levels = "b"))))
   expect_error(check_data(data.frame(fac = factor(c("a", "b", "z"))),
                           list(fac = factor(c("a", "b")))),
                "`levels(data.frame(fac = factor(c(\"a\", \"b\", \"z\")))$fac)` must have values matching 'a' or 'b'.",

--- a/tests/testthat/test-check-data.R
+++ b/tests/testthat/test-check-data.R
@@ -47,7 +47,7 @@ test_that("check_data fails", {
       data.frame(x = ordered(1:2)),
       values = list(x = ordered(1:2, levels = 2:1))
     ),
-    "^`levels[(]data.frame[(]x = ordered[(]1:2[)][)][$]x[)]` must have [(]the first occurence of[)] each of the following elements in the following order: '2', '1'[.]$"
+    "^`levels[(]data.frame[(]x = ordered[(]1:2[)][)][$]x[)]` must have each of the following elements in the following order: '2', '1'[.]$"
   )
 })
 
@@ -108,7 +108,7 @@ test_that("factors are handled correctly.", {
                              list(fac = factor(c("a", "b", "z"), c("a", "z", "b")))))
   expect_error(check_data(data.frame(fac = factor(c("a", "b", "z"), c("a", "z", "b"))),
                           list(fac = factor(c("a", "b", "z")))),
-               "`levels(data.frame(fac = factor(c(\"a\", \"b\", \"z\"), c(\"a\", \"z\", \"b\")))$fac)` must have (the first occurence of) each of the following elements in the following order: 'a', 'b', 'z'.",
+               "`levels(data.frame(fac = factor(c(\"a\", \"b\", \"z\"), c(\"a\", \"z\", \"b\")))$fac)` must have each of the following elements in the following order: 'a', 'b', 'z'.",
                fixed = TRUE)
   expect_no_error(check_data(data.frame(fac = factor(c("a", "b", "z"))),
                              list(fac = factor(c("a", NA), levels = c("a", "b", "z")))))

--- a/tests/testthat/test-check-data.R
+++ b/tests/testthat/test-check-data.R
@@ -54,7 +54,13 @@ test_that("check_data fails", {
 test_that("factors are handled correctly.", {
   # level doesn't matter: only checking that class is "factor" when check is 1 level and not NA
   expect_no_error(check_data(data.frame(fac = factor(c("a", "b", "c", "z"))),
-                             list(fac = factor("z"))))
+# level doesn't matter: only checking that class is "factor" when values is empty factor
+expect_no_error(check_data(data.frame(fac = factor(c("a", "b", "c", "z"))),
+                           list(fac = factor())))
+
+# level doesn't matter: only checking that class is "factor" when values is 1 level and not NA
+expect_no_error(check_data(data.frame(fac = factor(c("a", "b", "c", "z"))),
+                           list(fac = factor("z"))))
 
   # NAs are not required in the data set
   expect_no_error(check_data(data.frame(fac = factor(c("a", "z"))),

--- a/tests/testthat/test-check-values.R
+++ b/tests/testthat/test-check-values.R
@@ -42,22 +42,6 @@ test_that("check_values pass", {
     check_values(factor(1:3), factor(1:3)),
     check_values(factor(1:3), factor(1:3))
   )
-  expect_identical(
-    check_values(factor("a"), factor()),
-    check_values(factor("a"), factor())
-  )
-  expect_identical(
-    check_values(factor(c(1, NA)), factor(c(2, NA))),
-    check_values(factor(c(1, NA)), factor(c(2, NA)))
-  )
-  expect_identical(
-    check_values(factor(NA), factor(NA)),
-    check_values(factor(NA), factor(NA))
-  )
-  expect_identical(
-    check_values(factor(character(0)), factor("z")),
-    check_values(factor(character(0)), factor("z"))
-  )
 })
 
 test_that("check_values fail", {

--- a/tests/testthat/test-check-values.R
+++ b/tests/testthat/test-check-values.R
@@ -42,6 +42,14 @@ test_that("check_values pass", {
     check_values(factor(1:3), factor(1:3)),
     check_values(factor(1:3), factor(1:3))
   )
+  expect_identical(
+    check_values(factor("a"), factor()),
+    check_values(factor("a"), factor())
+  )
+  expect_identical(
+    check_values(factor(character(0)), factor("z")),
+    check_values(factor(character(0)), factor("z"))
+  )
 })
 
 test_that("check_values fail", {
@@ -99,6 +107,26 @@ test_that("check_values fail", {
   expect_chk_error(
     check_values(factor(1:2), factor(1:3)),
     "^`levels[(]factor[(]1:2[)][)]` must include '3'\\."
+  )
+
+  expect_chk_error(
+    check_values(factor(NA), factor("z")),
+    "^`factor[(]NA[)]` must not have any missing values[.]$"
+  )
+
+  expect_chk_error(
+    check_values(factor(1:3), factor(1:2)),
+    "^`levels[(]factor[(]1:3[)][)]` must have values matching '1' or '2'[.]$"
+  )
+
+  expect_chk_error(
+    check_values(factor(c(1, NA)), factor(c(2, NA))),
+    "^`levels[(]factor[(]c[(]1, NA[)][)][)]` must include '2'[.]$"
+  )
+
+  expect_chk_error(
+    check_values(1, NA_real_),
+    "^`1` must only have missing values[.]$"
   )
 
   expect_chk_error(

--- a/tests/testthat/test-check-values.R
+++ b/tests/testthat/test-check-values.R
@@ -47,6 +47,14 @@ test_that("check_values pass", {
     check_values(factor("a"), factor())
   )
   expect_identical(
+    check_values(factor(c(1, NA)), factor(c(2, NA))),
+    check_values(factor(c(1, NA)), factor(c(2, NA)))
+  )
+  expect_identical(
+    check_values(factor(NA), factor(NA)),
+    check_values(factor(NA), factor(NA))
+  )
+  expect_identical(
     check_values(factor(character(0)), factor("z")),
     check_values(factor(character(0)), factor("z"))
   )
@@ -120,8 +128,8 @@ test_that("check_values fail", {
   )
 
   expect_chk_error(
-    check_values(factor(c(1, NA)), factor(c(2, NA))),
-    "^`levels[(]factor[(]c[(]1, NA[)][)][)]` must include '2'[.]$"
+    check_values(factor("a"), factor(NA)),
+    "^`factor[(]\"a\"[)]` must only have missing values[.]$"
   )
 
   expect_chk_error(

--- a/tests/testthat/test-check-values.R
+++ b/tests/testthat/test-check-values.R
@@ -139,11 +139,11 @@ test_that("check_values fail", {
 
   expect_chk_error(
     check_values(factor(1:2), factor(1:2, levels = 2:1)),
-    "^`levels[(]factor[(]1:2[)][)]` must have [(]the first occurence of[)] each of the following elements in the following order: '2', '1'[.]$"
+    "^`levels[(]factor[(]1:2[)][)]` must have each of the following elements in the following order: '2', '1'[.]$"
   )
 
   expect_chk_error(
     check_values(ordered(1:2), ordered(1:2, levels = 2:1)),
-    "^`levels[(]ordered[(]1:2[)][)]` must have [(]the first occurence of[)] each of the following elements in the following order: '2', '1'[.]$"
+    "^`levels[(]ordered[(]1:2[)][)]` must have each of the following elements in the following order: '2', '1'[.]$"
   )
 })

--- a/tests/testthat/test-chk-orderset.R
+++ b/tests/testthat/test-chk-orderset.R
@@ -15,6 +15,6 @@ test_that("chk_orderset", {
   expect_invisible(chk_orderset(1, 1))
   expect_chk_error(
     chk_orderset(2:1, 1:2),
-    "`2:1` must have [(]the first occurence of[)] each of the following elements in the following order: 1, 2[.]$"
+    "`2:1` must have each of the following elements in the following order: 1, 2[.]$"
   )
 })


### PR DESCRIPTION
Addresses review comments on #298 and subsequent revisions agreed in review. Changes on top of the `issue-297` branch.

## Behaviour

`check_values()` (and hence `check_data()`) now applies the following rules for a factor `values`:

| `values` | Meaning |
|---|---|
| `factor()` | any factor (class check only) |
| `factor(1)` | any factor without missing values |
| `factor(c(1, NA))` | any factor with or without missing values |
| `factor(NA)` | any factor with all missing values |
| two or more levels | levels of x must be identical, including order, to the levels of values (with missing values governed by the presence of `NA` in values) |

This keeps the stricter level checking from #297/#298 for two or more levels while restoring the established one-level idioms (`factor(1)`, `factor(c(1, NA))`), which a reverse-dependency check showed `klexdatr` relies on.

## Fixes to #298

- `check_values(factor("a"), factor())` passes again: an empty factor checks class only, as documented.
- Removed `chk_gt(nlevels(x))`, which leaked the internal variable name in its error message (```nlevels(x)` must be greater than 0, not 0.``) and failed zero-length columns.
- Removed `chk_subset(unique(values), c(levels(values), NA))`, which was dead code: a factor's values are by construction its levels or `NA`.

## Other changes

- Dropped "(the first occurence of)" from the `chk_orderset()` error message (breaking change to the message text), so orderset failures now read: ```levels(data$fac)` must have each of the following elements in the following order: 'a', 'b', 'z'.`` No reverse dependency matches the old text (checked locally and via GitHub code search).
- Updated the `check_values()` `@details` to document the factor rules and the three one-level idioms.
- Added a `@details` cross-reference from `check_data()` to `check_values()` for the value-checking rules.
- Added direct `check_values()` tests for the fixed edge cases and revised behaviours (all written test-first).

## Verification

- Full suite: 1282 tests pass with no warnings.
- Reverse-dependency check: data-check test suites of `bisonpictools`, `klexdatr`, `kootlake`, `juvenilegerrard`, `obsbiascomp` and `ssddata` all pass against this branch (the one `bisonpictools` test error is pre-existing and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)